### PR TITLE
Fix for dragging of pins with custom images

### DIFF
--- a/ios/Classes/TiMapView.m
+++ b/ios/Classes/TiMapView.m
@@ -606,6 +606,7 @@
 - (void)mapView:(MKMapView *)mapView annotationView:(MKAnnotationView *)annotationView didChangeDragState:(MKAnnotationViewDragState)newState fromOldState:(MKAnnotationViewDragState)oldState
 {
 	[self firePinChangeDragState:annotationView newState:newState fromOldState:oldState];
+	if (newState == MKAnnotationViewDragStateEnding) annotationView.dragState = MKAnnotationViewDragStateNone;
 }
 
 - (void)firePinChangeDragState:(MKAnnotationView *) pinview newState:(MKAnnotationViewDragState)newState fromOldState:(MKAnnotationViewDragState)oldState 


### PR DESCRIPTION
Custom image pins are not "stamped" on the map when they've been dragged. They just kind of float around when you scroll the mapview. Setting dragstate to None when it's Ending seems to fix this.