### PR TITLE
Add polygon support for ios and android.

### DIFF
--- a/android/example/app.js
+++ b/android/example/app.js
@@ -39,7 +39,8 @@ var rows = [
     require('tests/multiMap'),
     require('tests/annotations'),
     require('tests/routes'),
-    require('tests/3d')
+    require('tests/3d'),
+    require('tests/polygons')
 ];
 
 if (IOS) {
@@ -64,3 +65,5 @@ function startUI() {
         rows[e.index].run && rows[e.index].run(UI, Map);
     });
 }
+
+

--- a/android/example/tests/annotations.js
+++ b/android/example/tests/annotations.js
@@ -98,4 +98,4 @@ exports.run = function(UI, Map) {
     });
     
     win.open();
-}
+};

--- a/android/example/tests/polygons.js
+++ b/android/example/tests/polygons.js
@@ -1,0 +1,111 @@
+
+exports.title = 'Polygons';
+exports.run = function(UI, Map) {
+    var win = UI.createWindow();
+
+    var rows = [
+        {
+            title: 'add poly1',
+            run: function(){
+                map.addPolygon(poly1);
+            }
+        },
+        {
+            title: 'rm poly1',
+            run: function(){
+                map.removePolygon(poly1);
+            }
+        },
+        {
+            title: 'rm all',
+            run: function(){
+                map.removeAllPolygons();
+            }
+        }
+    ];
+
+    var tableView = Ti.UI.createTableView({
+        top: '10%',
+        bottom: '50%',
+        data: rows
+    });
+    win.add(tableView);
+    tableView.addEventListener('click', function(e) {
+        rows[e.index].run && rows[e.index].run();
+    });
+
+    // Test points, holes, opacity, stroke width
+    var poly1 = Map.createPolygon({
+      points: [
+        {latitude: -33.855534, longitude: 151.200266},
+        {latitude: -33.859098, longitude: 151.230994},
+        {latitude: -33.877698, longitude: 151.225072},
+        {latitude: -33.875418, longitude: 151.201554}
+      ],
+      holes: [
+        [
+          {latitude: -33.870002, longitude: 151.210395},
+          [151.211939, -33.869503], // test array is valid
+          {latitude: -33.865940, longitude: 151.212540},
+          {latitude: -33.865084, longitude: 151.211682},
+          {latitude: -33.866439, longitude: 151.210738}
+        ],
+        [
+          {latitude: -33.858652, longitude: 151.204429},
+          {latitude: -33.858946, longitude: 151.205803},
+          {latitude: -33.860095, longitude: 151.205298},
+          {latitude: -33.860487, longitude: 151.204097},
+          {latitude: -33.859133, longitude: 151.204054}
+        ]
+      ],
+      fillColor: "rgba(237,5,42,75)",
+      strokeColor: "#912911",
+      strokeWidth: 10
+    }),
+
+    // Test counter-clockwise point definition, zIndex, points array
+    poly2 = Map.createPolygon({
+      points: [
+        [151.228290, -33.857280],
+        [151.224428, -33.855427],
+        [151.224170, -33.858991]
+      ],
+      fillColor: "#F2FA0C",
+      strokeColor: "#D4D93F",
+      strokeWidth: 5,
+      zIndex: 3
+    }),
+
+    // Test zIndex
+    poly3 = Map.createPolygon({
+      points: [
+        {latitude: -33.854429, longitude: 151.214429},
+        {latitude: -33.854928, longitude: 151.236101},
+        {latitude: -33.866189, longitude: 151.232668}
+      ],
+      fillColor: "#5EB0DB",
+      strokeColor: "#00679E",
+      strokeWidth: 5,
+      zIndex: 2
+    });
+
+
+
+    var map = Map.createView({
+        userLocation: true,
+        mapType: Map.NORMAL_TYPE,
+        animate: true,
+        polygons: [poly1, poly2, poly3],
+        region: {latitude: -33.87365, longitude: 151.20689, latitudeDelta:0.05, longitudeDelta:0.05}, //Sydney
+        top: '50%'
+    });
+    Ti.API.info("userLocation: " + map.userLocation);
+    win.add(map);
+
+    map.addEventListener('click', function(e) {
+        Ti.API.info("Latitude: " + e.latitude);
+        Ti.API.info("Source: " + e.clicksource);
+    });
+
+    win.open();
+};

--- a/android/example/tests/routes.js
+++ b/android/example/tests/routes.js
@@ -75,4 +75,4 @@ exports.run = function(UI, Map) {
     map.addRoute(route);
     
     win.open();
-}
+};

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 2.1.4
+version: 2.2.0
 apiversion: 2
 description: External version of Map module to support new Google Map v2 sdk
 author: Hieu Pham

--- a/android/src/ti/map/MapModule.java
+++ b/android/src/ti/map/MapModule.java
@@ -21,7 +21,13 @@ import com.google.android.gms.maps.model.BitmapDescriptorFactory;
 public class MapModule extends KrollModule
 {
 	public static final String PROPERTY_DRAGGABLE = "draggable";
+	public static final String PROPERTY_POLYGONS = "polygons";
 	public static final String PROPERTY_POINTS = "points";
+	public static final String PROPERTY_HOLES = "holes";
+	public static final String PROPERTY_FILL_COLOR = "fillColor";
+	public static final String PROPERTY_STROKE_COLOR = "strokeColor";
+	public static final String PROPERTY_STROKE_WIDTH = "strokeWidth";
+	public static final String PROPERTY_GEODESIC_STATUS = "geodesicStatus";
 	public static final String PROPERTY_TRAFFIC = "traffic";
 	public static final String PROPERTY_MAP = "map";
 	public static final String PROPERTY_NEWSTATE = "newState";

--- a/android/src/ti/map/PolygonProxy.java
+++ b/android/src/ti/map/PolygonProxy.java
@@ -1,0 +1,144 @@
+package ti.map;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import org.appcelerator.kroll.KrollProxy;
+import org.appcelerator.kroll.annotations.Kroll;
+import org.appcelerator.titanium.TiC;
+import org.appcelerator.titanium.TiContext;
+import org.appcelerator.titanium.util.TiConvert;
+
+import com.google.android.gms.maps.model.LatLng;
+import com.google.android.gms.maps.model.PolygonOptions;
+
+@Kroll.proxy(creatableInModule = MapModule.class, propertyAccessors = {
+		MapModule.PROPERTY_POINTS, MapModule.PROPERTY_HOLES,
+		MapModule.PROPERTY_FILL_COLOR, MapModule.PROPERTY_STROKE_COLOR,
+		MapModule.PROPERTY_STROKE_WIDTH, TiC.PROPERTY_ZINDEX,
+		TiC.PROPERTY_VISIBLE, MapModule.PROPERTY_GEODESIC_STATUS })
+public class PolygonProxy extends KrollProxy {
+	private TiPolygon polygon;
+	private PolygonOptions options;
+
+	public PolygonProxy() {
+		super();
+	}
+
+	public PolygonProxy(TiContext tiContext) {
+		this();
+	}
+
+	public void setTiPolygon(TiPolygon p) {
+		polygon = p;
+	}
+
+	public TiPolygon getTiPolygon() {
+		return polygon;
+	}
+
+	public PolygonOptions getOptions() {
+		return options;
+	}
+
+	public void processOptions() {
+
+		options = new PolygonOptions();
+
+		if (hasProperty(MapModule.PROPERTY_POINTS)) {
+			processPoints(getProperty(MapModule.PROPERTY_POINTS));
+		}
+
+		if (hasProperty(MapModule.PROPERTY_HOLES)) {
+			processHoles(getProperty(MapModule.PROPERTY_HOLES));
+		}
+
+		if (hasProperty(MapModule.PROPERTY_FILL_COLOR)) {
+			options.fillColor(TiConvert
+					.toColor((String) getProperty(MapModule.PROPERTY_FILL_COLOR)));
+		}
+
+		if (hasProperty(MapModule.PROPERTY_STROKE_COLOR)) {
+			options.strokeColor(TiConvert
+					.toColor((String) getProperty(MapModule.PROPERTY_STROKE_COLOR)));
+		}
+
+		if (hasProperty(MapModule.PROPERTY_STROKE_WIDTH)) {
+			options.strokeWidth(TiConvert
+					.toFloat(getProperty(MapModule.PROPERTY_STROKE_WIDTH)));
+		}
+
+		if (hasProperty(TiC.PROPERTY_ZINDEX)) {
+			options.zIndex(TiConvert.toFloat(getProperty(TiC.PROPERTY_ZINDEX)));
+		}
+
+		if (hasProperty(TiC.PROPERTY_VISIBLE)) {
+			options.visible(TiConvert
+					.toBoolean(getProperty(TiC.PROPERTY_VISIBLE)));
+		}
+
+		if (hasProperty(MapModule.PROPERTY_GEODESIC_STATUS)) {
+			options.geodesic(TiConvert
+					.toBoolean(getProperty(MapModule.PROPERTY_GEODESIC_STATUS)));
+		}
+	}
+
+	public void processPoints(Object points) {
+		if (points instanceof Object[]) {
+			Object[] pointsArray = (Object[]) points;
+			for (int i = 0; i < pointsArray.length; i++) {
+				Object obj = pointsArray[i];
+				addLocation(obj);
+			}
+		}
+	}
+
+	public void addLocation(Object loc) {
+		LatLng location = parseLocation(loc);
+		if (location != null) {
+			options.add(location);
+		}
+	}
+
+	// Expects holes to be a 2-d array of points
+	public void processHoles(Object holes) {
+		if (holes instanceof Object[]) {
+			Object[] holesArray = (Object[]) holes;
+			for (int i = 0; i < holesArray.length; i++) {
+				ArrayList<LatLng> hole = new ArrayList<LatLng>();
+
+				Object[] holeObj = (Object[]) holesArray[i];
+				for (int j = 0; j < holeObj.length; j++) {
+					Object obj = holeObj[j];
+					LatLng location = parseLocation(obj);
+					if (location != null) {
+						hole.add(location);
+					}
+				}
+
+				if (hole.size() > 0) {
+					options.addHole(hole);
+				}
+			}
+		}
+	}
+
+	// A location can either be a an array of longitude, latitude pairings or
+	// an array of longitude, latitude objects.
+	// e.g. [123.33, 34.44], OR {longitude: 123.33, latitude, 34.44}
+	private LatLng parseLocation(Object loc) {
+		LatLng location = null;
+		if (loc instanceof HashMap) {
+			HashMap<String, String> point = (HashMap<String, String>) loc;
+			location = new LatLng(TiConvert.toDouble(point
+					.get(TiC.PROPERTY_LATITUDE)), TiConvert.toDouble(point
+					.get(TiC.PROPERTY_LONGITUDE)));
+		} else if (loc instanceof Object[]) {
+			Object[] temp = (Object[]) loc;
+			location = new LatLng(TiConvert.toDouble(temp[1]),
+					TiConvert.toDouble(temp[0]));
+		}
+		return location;
+	}
+
+}

--- a/android/src/ti/map/TiPolygon.java
+++ b/android/src/ti/map/TiPolygon.java
@@ -1,0 +1,32 @@
+/**
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2013 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+package ti.map;
+
+import com.google.android.gms.maps.model.Polygon;
+
+public class TiPolygon {
+	private Polygon polygon;
+	private final PolygonProxy proxy;
+
+	public TiPolygon(Polygon p, PolygonProxy pp) {
+		polygon = p;
+		proxy = pp;
+	}
+
+	public void setPolygon(Polygon p) {
+		polygon = p;
+	}
+
+	public Polygon getPolygon() {
+		return polygon;
+	}
+
+	public PolygonProxy getProxy() {
+		return proxy;
+	}
+}

--- a/android/src/ti/map/ViewProxy.java
+++ b/android/src/ti/map/ViewProxy.java
@@ -33,14 +33,15 @@ import android.os.Message;
 	TiC.PROPERTY_ANIMATE,
 	MapModule.PROPERTY_TRAFFIC,
 	TiC.PROPERTY_ENABLE_ZOOM_CONTROLS,
-	MapModule.PROPERTY_COMPASS_ENABLED
+	MapModule.PROPERTY_COMPASS_ENABLED,
+	MapModule.PROPERTY_POLYGONS
 })
 public class ViewProxy extends TiViewProxy
 {
 	private static final String TAG = "MapViewProxy";
-		
+
 	private static final int MSG_FIRST_ID = TiViewProxy.MSG_LAST_ID + 1;
-	
+
 	private static final int MSG_ADD_ANNOTATION = MSG_FIRST_ID + 500;
 	private static final int MSG_ADD_ANNOTATIONS = MSG_FIRST_ID + 501;
 	private static final int MSG_REMOVE_ANNOTATION = MSG_FIRST_ID + 502;
@@ -48,32 +49,36 @@ public class ViewProxy extends TiViewProxy
 	private static final int MSG_REMOVE_ALL_ANNOTATIONS = MSG_FIRST_ID + 504;
 	private static final int MSG_SELECT_ANNOTATION = MSG_FIRST_ID + 505;
 	private static final int MSG_DESELECT_ANNOTATION = MSG_FIRST_ID + 506;
-	private static final int MSG_ADD_ROUTE = MSG_FIRST_ID + 507;	
+	private static final int MSG_ADD_ROUTE = MSG_FIRST_ID + 507;
 	private static final int MSG_REMOVE_ROUTE = MSG_FIRST_ID + 508;
 	private static final int MSG_CHANGE_ZOOM = MSG_FIRST_ID + 509;
 	private static final int MSG_SET_LOCATION = MSG_FIRST_ID + 510;
 	private static final int MSG_MAX_ZOOM = MSG_FIRST_ID + 511;
 	private static final int MSG_MIN_ZOOM = MSG_FIRST_ID + 512;
 	private static final int MSG_SNAP_SHOT = MSG_FIRST_ID + 513;
-	
-	private ArrayList<RouteProxy> preloadRoutes;
-	
+	private static final int MSG_ADD_POLYGON = MSG_FIRST_ID + 514;
+	private static final int MSG_REMOVE_POLYGON = MSG_FIRST_ID + 515;
+	private static final int MSG_REMOVE_ALL_POLYGONS = MSG_FIRST_ID + 516;
+
+	private final ArrayList<RouteProxy> preloadRoutes;
+
 	public ViewProxy() {
 		super();
 		preloadRoutes = new ArrayList<RouteProxy>();
 		defaultValues.put(MapModule.PROPERTY_COMPASS_ENABLED, true);
 	}
-	
+
+	@Override
 	public TiUIView createView(Activity activity) {
 		return new TiUIMapView(this, activity);
 	}
-	
+
 	public void clearPreloadObjects() {
 		preloadRoutes.clear();
 	}
 
 	@Override
-	public boolean handleMessage(Message msg) 
+	public boolean handleMessage(Message msg)
 	{
 		AsyncResult result = null;
 		switch (msg.what) {
@@ -84,7 +89,7 @@ public class ViewProxy extends TiViewProxy
 			result.setResult(null);
 			return true;
 		}
-		
+
 		case MSG_ADD_ANNOTATIONS: {
 			result = (AsyncResult) msg.obj;
 			handleAddAnnotations((Object[])result.getArg());
@@ -98,55 +103,55 @@ public class ViewProxy extends TiViewProxy
 			result.setResult(null);
 			return true;
 		}
-		
+
 		case MSG_REMOVE_ANNOTATIONS: {
 			result = (AsyncResult) msg.obj;
 			handleRemoveAnnotations((Object[])result.getArg());
 			result.setResult(null);
 			return true;
 		}
-		
+
 		case MSG_REMOVE_ALL_ANNOTATIONS: {
 			result = (AsyncResult) msg.obj;
 			handleRemoveAllAnnotations();
 			result.setResult(null);
 			return true;
 		}
-		
+
 		case MSG_SELECT_ANNOTATION: {
 			result = (AsyncResult) msg.obj;
 			handleSelectAnnotation(result.getArg());
 			result.setResult(null);
 			return true;
 		}
-		
+
 		case MSG_DESELECT_ANNOTATION: {
 			result = (AsyncResult) msg.obj;
 			handleDeselectAnnotation(result.getArg());
 			result.setResult(null);
 			return true;
 		}
-		
+
 		case MSG_ADD_ROUTE: {
 			result = (AsyncResult) msg.obj;
-			handleAddRoute((RouteProxy)result.getArg());
+			handleAddRoute(result.getArg());
 			result.setResult(null);
 			return true;
 		}
-		
+
 		case MSG_REMOVE_ROUTE: {
 			result = (AsyncResult) msg.obj;
 			handleRemoveRoute((RouteProxy)result.getArg());
 			result.setResult(null);
 			return true;
 		}
-		
+
 		case MSG_MAX_ZOOM: {
 			result = (AsyncResult) msg.obj;
 			result.setResult(getMaxZoom());
 			return true;
 		}
-		
+
 		case MSG_MIN_ZOOM: {
 			result = (AsyncResult) msg.obj;
 			result.setResult(getMinZoom());
@@ -165,6 +170,27 @@ public class ViewProxy extends TiViewProxy
 
 		case MSG_SNAP_SHOT: {
 			handleSnapshot();
+			return true;
+		}
+
+		case MSG_ADD_POLYGON: {
+			result = (AsyncResult) msg.obj;
+			handleAddPolygon((PolygonProxy) result.getArg());
+			result.setResult(null);
+			return true;
+		}
+
+		case MSG_REMOVE_POLYGON: {
+			result = (AsyncResult) msg.obj;
+			handleRemovePolygon((PolygonProxy) result.getArg());
+			result.setResult(null);
+			return true;
+		}
+
+		case MSG_REMOVE_ALL_POLYGONS: {
+			result = (AsyncResult) msg.obj;
+			handleRemoveAllPolygons();
+			result.setResult(null);
 			return true;
 		}
 
@@ -195,12 +221,12 @@ public class ViewProxy extends TiViewProxy
 			}
 		}
 	}
-	
+
 	private void handleAddAnnotation(AnnotationProxy annotation) {
 		TiUIMapView mapView = (TiUIMapView) peekView();
 		if (mapView.getMap() != null) {
 			mapView.addAnnotation(annotation);
-		} 
+		}
 	}
 
 	@Kroll.method
@@ -227,7 +253,7 @@ public class ViewProxy extends TiViewProxy
 			}
 		}
 	}
-	
+
 	private void handleAddAnnotations(Object[] annotations) {
 		for (int i = 0; i < annotations.length; i++) {
 			Object annotation = annotations[i];
@@ -236,7 +262,7 @@ public class ViewProxy extends TiViewProxy
 			}
 		}
 	}
-	
+
 	@Kroll.method
 	public void snapshot()
 	{
@@ -246,8 +272,8 @@ public class ViewProxy extends TiViewProxy
 			getMainHandler().obtainMessage(MSG_SNAP_SHOT).sendToTarget();
 		}
 	}
-	
-	private void handleSnapshot() 
+
+	private void handleSnapshot()
 	{
 		TiUIView view = peekView();
 		if (view instanceof TiUIMapView) {
@@ -266,7 +292,7 @@ public class ViewProxy extends TiViewProxy
 			TiMessenger.sendBlockingMainMessage(getMainHandler().obtainMessage(MSG_REMOVE_ALL_ANNOTATIONS));
 		}
 	}
-	
+
 	public void handleRemoveAllAnnotations() {
 		TiUIView view = peekView();
 		if (view instanceof TiUIMapView) {
@@ -274,7 +300,7 @@ public class ViewProxy extends TiViewProxy
 			mapView.removeAllAnnotations();
 		}
 	}
-	
+
 	public boolean isAnnotationValid(Object annotation) {
 		//Incorrect argument types
 		if (!(annotation instanceof AnnotationProxy || annotation instanceof String)) {
@@ -285,7 +311,7 @@ public class ViewProxy extends TiViewProxy
 		if (annotation instanceof AnnotationProxy && ((AnnotationProxy)annotation).getTiMarker() == null) {
 			return false;
 		}
-		
+
 		if (annotation instanceof String) {
 			TiUIView view = peekView();
 			if (view instanceof TiUIMapView) {
@@ -295,7 +321,7 @@ public class ViewProxy extends TiViewProxy
 				}
 			}
 		}
-		
+
 		return true;
 	}
 
@@ -343,9 +369,9 @@ public class ViewProxy extends TiViewProxy
 			} else {
 				TiMessenger.sendBlockingMainMessage(getMainHandler().obtainMessage(MSG_REMOVE_ANNOTATION), annotation);
 			}
-		}	
+		}
 	}
-	
+
 	@Kroll.method
 	public void removeAnnotations(Object annos) {
 		//Update the JS object
@@ -369,7 +395,7 @@ public class ViewProxy extends TiViewProxy
 			}
 		}
 	}
-	
+
 	public void handleRemoveAnnotations(Object[] annotations) {
 		for (int i = 0; i < annotations.length; i++) {
 			Object annotation = annotations[i];
@@ -378,14 +404,14 @@ public class ViewProxy extends TiViewProxy
 			}
 		}
 	}
-	
+
 	public void handleRemoveAnnotation(Object annotation) {
 		TiUIMapView mapView = (TiUIMapView) peekView();
 		if (mapView.getMap() != null) {
 			mapView.removeAnnotation(annotation);
 		}
 	}
-	
+
 	@Kroll.method
 	public void selectAnnotation(Object annotation) {
 		if (!isAnnotationValid(annotation)) {
@@ -398,14 +424,14 @@ public class ViewProxy extends TiViewProxy
 			TiMessenger.sendBlockingMainMessage(getMainHandler().obtainMessage(MSG_SELECT_ANNOTATION), annotation);
 		}
 	}
-	
+
 	public void handleSelectAnnotation(Object annotation) {
 		TiUIView view = peekView();
 		if (view instanceof TiUIMapView) {
 			((TiUIMapView)view).selectAnnotation(annotation);
 		}
 	}
-	
+
 	@Kroll.method
 	public void deselectAnnotation(Object annotation) {
 		if (!isAnnotationValid(annotation)) {
@@ -418,17 +444,17 @@ public class ViewProxy extends TiViewProxy
 			TiMessenger.sendBlockingMainMessage(getMainHandler().obtainMessage(MSG_DESELECT_ANNOTATION), annotation);
 		}
 	}
-	
+
 	public void handleDeselectAnnotation(Object annotation) {
 		TiUIView view = peekView();
 		if (view instanceof TiUIMapView) {
 			((TiUIMapView)view).deselectAnnotation(annotation);
 		}
 	}
-	
+
 	@Kroll.method
 	public void addRoute(RouteProxy route) {
-		
+
 		if (TiApplication.isUIThread()) {
 			handleAddRoute(route);
 		} else {
@@ -436,7 +462,7 @@ public class ViewProxy extends TiViewProxy
 
 		}
 	}
-	
+
 	public void handleAddRoute(Object route) {
 		if (route == null) {
 			return;
@@ -456,19 +482,19 @@ public class ViewProxy extends TiViewProxy
 		}
 
 	}
-	
+
 	public void addPreloadRoute(RouteProxy r) {
 		if (!preloadRoutes.contains(r)) {
 			preloadRoutes.add(r);
 		}
 	}
-	
+
 	public void removePreloadRoute(RouteProxy r) {
 		if (preloadRoutes.contains(r)) {
 			preloadRoutes.remove(r);
 		}
 	}
-	
+
 	public float getMaxZoom()
 	{
 		TiUIView view = peekView();
@@ -478,7 +504,7 @@ public class ViewProxy extends TiViewProxy
 			return 0;
 		}
 	}
-	
+
 	public float getMinZoom()
 	{
 		TiUIView view = peekView();
@@ -490,7 +516,7 @@ public class ViewProxy extends TiViewProxy
 	}
 
 	@Kroll.method @Kroll.getProperty
-	public float getMaxZoomLevel() 
+	public float getMaxZoomLevel()
 	{
 		if (TiApplication.isUIThread()) {
 			return getMaxZoom();
@@ -498,9 +524,9 @@ public class ViewProxy extends TiViewProxy
 			return (Float) TiMessenger.sendBlockingMainMessage(getMainHandler().obtainMessage(MSG_MAX_ZOOM));
 		}
 	}
-	
+
 	@Kroll.method @Kroll.getProperty
-	public float getMinZoomLevel() 
+	public float getMinZoomLevel()
 	{
 		if (TiApplication.isUIThread()) {
 			return getMinZoom();
@@ -508,8 +534,8 @@ public class ViewProxy extends TiViewProxy
 			return (Float) TiMessenger.sendBlockingMainMessage(getMainHandler().obtainMessage(MSG_MIN_ZOOM));
 		}
 	}
-	
-	
+
+
 	@Kroll.method
 	public void removeRoute(RouteProxy route) {
 		if (TiApplication.isUIThread()) {
@@ -519,7 +545,7 @@ public class ViewProxy extends TiViewProxy
 
 		}
 	}
-	
+
 	public void handleRemoveRoute(RouteProxy route) {
 		TiUIView view = peekView();
 		if (view instanceof TiUIMapView) {
@@ -534,7 +560,7 @@ public class ViewProxy extends TiViewProxy
 			removePreloadRoute(route);
 		}
 	}
-	
+
 	public ArrayList<RouteProxy> getPreloadRoutes() {
 		return preloadRoutes;
 	}
@@ -583,4 +609,64 @@ public class ViewProxy extends TiViewProxy
 			Log.e(TAG, "Unable set location since the map view has not been created yet. Use setRegion() instead.");
 		}
 	}
+
+
+	@Kroll.method
+	public void addPolygon(PolygonProxy poly) {
+		if (TiApplication.isUIThread()) {
+			handleAddPolygon(poly);
+		} else {
+			TiMessenger.sendBlockingMainMessage(getMainHandler().obtainMessage(MSG_ADD_POLYGON), poly);
+
+		}
+	}
+
+	private void handleAddPolygon(PolygonProxy poly) {
+		TiUIView view = peekView();
+		if (view instanceof TiUIMapView) {
+			TiUIMapView mapView = (TiUIMapView) view;
+			if (mapView.getMap() != null) {
+				mapView.addPolygon(poly);
+			}
+		}
+	}
+
+
+	@Kroll.method
+	public void removePolygon(PolygonProxy poly) {
+		if (TiApplication.isUIThread()) {
+			handleRemovePolygon(poly);
+		} else {
+			TiMessenger.sendBlockingMainMessage(getMainHandler().obtainMessage(MSG_REMOVE_POLYGON), poly);
+		}
+	}
+
+	public void handleRemovePolygon(PolygonProxy poly) {
+		TiUIView view = peekView();
+		if (view instanceof TiUIMapView) {
+			TiUIMapView mapView = (TiUIMapView) view;
+			if (mapView.getMap() != null) {
+				mapView.removePolygon(poly);
+			}
+		}
+	}
+
+	@Kroll.method
+	public void removeAllPolygons() {
+		if (TiApplication.isUIThread()) {
+			handleRemoveAllPolygons();
+		} else {
+			TiMessenger.sendBlockingMainMessage(getMainHandler().obtainMessage(MSG_REMOVE_ALL_POLYGONS));
+		}
+	}
+
+	public void handleRemoveAllPolygons() {
+		TiUIView view = peekView();
+		if (view instanceof TiUIMapView) {
+			TiUIMapView mapView = (TiUIMapView) view;
+			mapView.removeAllPolygons();
+		}
+	}
+
+
 }

--- a/apidoc/Annotation.yml
+++ b/apidoc/Annotation.yml
@@ -2,7 +2,7 @@
 name: Modules.Map.Annotation
 summary: Represents a labeled point of interest on the map that the user can click on.
 description: |
-    The `Annotation` object gives you low-level control over annotations that can be added to 
+    The `Annotation` object gives you low-level control over annotations that can be added to
     [map view](Modules.Map.View). An annotation must have its `latitude` and `longitude`
     properties set to appear on a map.
 
@@ -15,31 +15,31 @@ description: |
     The controls on the left and right side of the annotation can be specified in one of two
     ways:
 
-    * To display an image, set the [leftButton](Titanium.Map.Annotation.leftButton) or 
-      [rightButton](Titanium.Map.Annotation.rightButton) property to an image URL. (On 
-      iOS, you can also use a [SystemButton](Titanium.UI.iPhone.SystemButton) constant 
-      to use one of the native system button icons.) 
+    * To display an image, set the [leftButton](Titanium.Map.Annotation.leftButton) or
+      [rightButton](Titanium.Map.Annotation.rightButton) property to an image URL. (On
+      iOS, you can also use a [SystemButton](Titanium.UI.iPhone.SystemButton) constant
+      to use one of the native system button icons.)
 
-    * To add another type of view to the annotation, set the 
-      [leftView](Titanium.Map.Annotation.leftView) or 
+    * To add another type of view to the annotation, set the
+      [leftView](Titanium.Map.Annotation.leftView) or
       [rightView](Titanium.Map.Annotation.rightView) property to a [View](Titanium.UI.View)
       object.
 
     An annotation has two states: selected and deselected. A deselected annotation
-    is marked by a pin image. When the user selects the pin, the full annotation is 
+    is marked by a pin image. When the user selects the pin, the full annotation is
     displayed.
 
     You can specify a custom image for the map pin by setting the
-    [image](Modules.Map.Annotation.image) property. 
+    [image](Modules.Map.Annotation.image) property.
 
-    When the user clicks on an annotation, a `click` event is generated. 
+    When the user clicks on an annotation, a `click` event is generated.
 
-    On iOS, You can add a click event listener to a specific annotation, or add a 
-    click event listener to the map view to receive click events from all annotations 
+    On iOS, You can add a click event listener to a specific annotation, or add a
+    click event listener to the map view to receive click events from all annotations
     on the map.
 
     On Android, you must add the click event listener to the map view; the annotation
-    itself does not generate these events. 
+    itself does not generate these events.
 
 extends: Titanium.Proxy
 since: { android: "3.0.2", iphone: "3.2.0", ipad: "3.2.0" }
@@ -90,7 +90,7 @@ properties:
     type: String
     default: If not specified, a standard map pin image is used.
 
-  - name: latitude 
+  - name: latitude
     summary: Latitude of the annotation, in decimal degrees.
     type: Number
 
@@ -148,7 +148,7 @@ properties:
         This is ignored if the `rightButton` property is set.
     type: Titanium.UI.View
     since: "3.1.0"
-  
+
   - name: showInfoWindow
     summary: Show or hide the view that is displayed on the annotation when clicked.
     description: |
@@ -159,4 +159,4 @@ properties:
     type: Boolean
     default: true
     since: "3.2.0"
-    
+

--- a/apidoc/Map.yml
+++ b/apidoc/Map.yml
@@ -123,7 +123,7 @@ properties:
 
   - name: ANNOTATION_DRAG_STATE_START
     summary: |
-        Used in the [pinchangedragstate](Modules.Map.View.pinchangedragstate) event 
+        Used in the [pinchangedragstate](Modules.Map.View.pinchangedragstate) event
         to indicate that the user started dragging the annotation.
     type: Number
     permission: read-only
@@ -131,7 +131,7 @@ properties:
 
   - name: ANNOTATION_DRAG_STATE_END
     summary: |
-        Used in the [pinchangedragstate](Modules.Map.View.pinchangedragstate) event 
+        Used in the [pinchangedragstate](Modules.Map.View.pinchangedragstate) event
         to indicate that the user finished moving the annotation.
     type: Number
     permission: read-only
@@ -139,51 +139,51 @@ properties:
 
   - name: ANNOTATION_GREEN
     summary: |
-        Color constant used to set a map annotation to green via the 
+        Color constant used to set a map annotation to green via the
         <Modules.Map.Annotation.pincolor> property.
     type: Number
     permission: read-only
-    
+
   - name: ANNOTATION_BLUE
     summary: |
-        Color constant used to set a map annotation to blue via the 
+        Color constant used to set a map annotation to blue via the
         <Modules.Map.Annotation.pincolor> property.
     type: Number
     permission: read-only
     platforms: [android]
-    
+
   - name: ANNOTATION_AZURE
     summary: |
-        Color constant used to set a map annotation to azure via the 
+        Color constant used to set a map annotation to azure via the
         <Modules.Map.Annotation.pincolor> property.
     type: Number
     permission: read-only
     platforms: [android]
-    
+
   - name: ANNOTATION_CYAN
     summary: |
-        Color constant used to set a map annotation to cyan via the 
+        Color constant used to set a map annotation to cyan via the
         <Modules.Map.Annotation.pincolor> property.
     type: Number
     permission: read-only
     platforms: [android]
-    
+
   - name: ANNOTATION_MAGENTA
     summary: |
-        Color constant used to set a map annotation to magenta via the 
+        Color constant used to set a map annotation to magenta via the
         <Modules.Map.Annotation.pincolor> property.
     type: Number
     permission: read-only
     platforms: [android]
-    
+
   - name: ANNOTATION_ORANGE
     summary: |
-        Color constant used to set a map annotation to orange via the 
+        Color constant used to set a map annotation to orange via the
         <Modules.Map.Annotation.pincolor> property.
     type: Number
     permission: read-only
     platforms: [android]
-    
+
   - name: ANNOTATION_PURPLE
     summary: |
         Color constant used to set a map annotation to purple via the
@@ -194,15 +194,15 @@ properties:
 
   - name: ANNOTATION_ROSE
     summary: |
-        Color constant used to set a map annotation to rose via the 
+        Color constant used to set a map annotation to rose via the
         <Modules.Map.Annotation.pincolor> property.
     type: Number
     permission: read-only
     platforms: [android]
-    
+
   - name: ANNOTATION_YELLOW
     summary: |
-        Color constant used to set a map annotation to yellow via the 
+        Color constant used to set a map annotation to yellow via the
         <Modules.Map.Annotation.pincolor> property.
     type: Number
     permission: read-only
@@ -210,35 +210,35 @@ properties:
 
   - name: ANNOTATION_VIOLET
     summary: |
-        Color constant used to set a map annotation to violet via the 
+        Color constant used to set a map annotation to violet via the
         <Modules.Map.Annotation.pincolor> property.
     type: Number
     permission: read-only
     platforms: [android]
-    
+
   - name: ANNOTATION_RED
     summary: |
-        Color constant used to set a map annotation to red via the 
+        Color constant used to set a map annotation to red via the
         <Modules.Map.Annotation.pincolor> property.
     type: Number
     permission: read-only
-    
+
   - name: SATELLITE_TYPE
     summary: Used with [mapType](Modules.Map.View.mapType) to display satellite imagery of the area.
     type: Number
     permission: read-only
-    
+
   - name: NORMAL_TYPE
     summary: Used with [mapType](Modules.Map.View.mapType) to display a street map that shows the position of all roads and some road names.
     type: Number
     permission: read-only
-    
+
   - name: TERRAIN_TYPE
     summary: Used with [mapType](Modules.Map.View.mapType) to display the terrain that shows the position of all roads and some road names.
     type: Number
     permission: read-only
     platforms: [android]
-    
+
   - name: HYBRID_TYPE
     summary: Used with [mapType](Modules.Map.View.mapType) to display a satellite image of the area with road and road name information layered on top.
     type: Number
@@ -249,25 +249,25 @@ properties:
     type: Number
     permission: read-only
     platforms: [android]
-    
+
   - name: SERVICE_MISSING
     summary: Code returned from <Modules.Map.isGooglePlayServicesAvailable>. Google Play services is not installed on the device.
     type: Number
     permission: read-only
     platforms: [android]
-    
+
   - name: SERVICE_VERSION_UPDATE_REQUIRED
     summary: Code returned from <Modules.Map.isGooglePlayServicesAvailable>. Google Play services is out of date.
     type: Number
     permission: read-only
     platforms: [android]
-    
+
   - name: SERVICE_DISABLED
     summary: Code returned from <Modules.Map.isGooglePlayServicesAvailable>. Google Play services has been disabled on this device.
     type: Number
     permission: read-only
     platforms: [android]
-    
+
   - name: SERVICE_INVALID
     summary: Code returned from <Modules.Map.isGooglePlayServicesAvailable>. The version of Google Play services installed on this device is not authentic.
     type: Number
@@ -280,10 +280,10 @@ properties:
     permission: read-only
     since: "3.2.0"
     platforms: [iphone, ipad]
-    
+
   - name: OVERLAY_LEVEL_ABOVE_ROADS
     summary: |
-        Place the overlay above map labels, shields, or point-of-interest icons but below annotations and 3D projections of buildings. 
+        Place the overlay above map labels, shields, or point-of-interest icons but below annotations and 3D projections of buildings.
         Available in iOS 7.0 and later.
     type: Number
     permission: read-only
@@ -302,18 +302,18 @@ methods:
     summary: Returns a code to indicate whether Google Play Services is available on the device.
     since: "3.1.1"
     platforms: [android]
-    
-    
+
+
 examples:
   - title: Map Example
     example: |
-        This is a basic map example that places a custom annotation on the map, and 
-        listens for click events on the annotation. 
+        This is a basic map example that places a custom annotation on the map, and
+        listens for click events on the annotation.
 
         In this example, a custom property (`myid`) is added to the annotation object.
         While adding custom members to a Titanium object is not generally recommended,
         in this case it provides a mechanism for uniquely identifying an annotation. This
-        can be useful, for example, if the annotations are dynamically generated 
+        can be useful, for example, if the annotations are dynamically generated
         and it is not practical to identify them by title.
 
             var Map = require('ti.map');

--- a/apidoc/Polygon.yml
+++ b/apidoc/Polygon.yml
@@ -1,0 +1,56 @@
+---
+name: Modules.Map.Polygon
+summary: Represents a bounded area on the map.
+description: |
+    The `Polygon` object gives you low-level control over polygons that can be added to a
+    [map view](Modules.Map.View). A polygon must have its `points` property set to appear on a map.
+
+    Use the <Modules.Map.createPolygon> method to create a polygon.
+
+extends: Titanium.Proxy
+since: { android: "3.2.3", iphone: "3.2.3", ipad: "3.2.3" }
+platforms: [android, iphone, ipad]
+
+properties:
+
+  - name: points
+    summary: Array of map points making up the polygon. Can also be an array of longitude, latitude touples.
+    availability: creation
+    type: Array<MapPointType>
+    optional: false
+
+  - name: holes
+    summary: Array of points arrays that define holes in the polygon.
+    availability: creation
+    type: Array<Array<MapPointType>>
+    optional: true
+
+  - name: fillColor
+    summary: |
+        Color to use when shading the polgyon, as a color name or hex triplet.
+    description: |
+        For information about color values, see the "Colors" section of <Titanium.UI>.
+    type: String
+    default: black
+
+  - name: strokeColor
+    summary: |
+        Color to use for the border of the polgyon, as a color name or hex triplet.
+    description: |
+        For information about color values, see the "Colors" section of <Titanium.UI>.
+    type: String
+    default: black
+
+  - name: strokeWidth
+    summary: Line width in pixels to use when drawing the polygon.
+    type: Number
+    default: 10
+
+  - name: zIndex
+    summary: |
+        The order (depth) in which to display the polygons.
+    description: |
+        For iOS, the polygons are drawn in the order in which they are added.
+    availability: creation
+    type: Number
+    platforms: [android]

--- a/ios/Classes/TiMapPolygonProxy.h
+++ b/ios/Classes/TiMapPolygonProxy.h
@@ -1,0 +1,36 @@
+//
+//  TiMapPolygonProxy.h
+//  map
+//
+//  Created by Adam St. John on 2014-06-09.
+//
+//
+
+#import "TiBase.h"
+#import "TiViewProxy.h"
+#import <MapKit/MapKit.h>
+
+@class TiMapViewProxy;
+
+@interface TiMapPolygonProxy : TiProxy {
+    
+
+    MKPolygon *polygon;
+    MKPolygonRenderer *polygonRenderer;
+    
+//    unsigned int zIndex;
+    float strokeWidth;
+    TiColor *fillColor;
+    TiColor *strokeColor;
+    
+}
+
+
+
+@property (nonatomic, readonly) MKPolygon *polygon;
+@property (nonatomic, readonly) MKPolygonRenderer *polygonRenderer;
+
+
+
+
+@end

--- a/ios/Classes/TiMapPolygonProxy.m
+++ b/ios/Classes/TiMapPolygonProxy.m
@@ -1,0 +1,178 @@
+//
+//  TiMapPolygonProxy.m
+//  map
+//
+//  Created by Adam St. John on 2014-06-09.
+//
+//
+
+#import "TiMapPolygonProxy.h"
+
+
+
+
+@implementation TiMapPolygonProxy
+
+
+@synthesize polygon, polygonRenderer;
+
+
+-(void)dealloc
+{
+    
+    RELEASE_TO_NIL(polygon);
+    RELEASE_TO_NIL(polygonRenderer);
+    RELEASE_TO_NIL(fillColor);
+    RELEASE_TO_NIL(strokeColor);
+	
+	[super dealloc];
+}
+
+-(void)_initWithProperties:(NSDictionary*)properties
+{
+    if ([properties objectForKey:@"points"] == nil) {
+        [self throwException:@"missing required points property" subreason:nil location:CODELOCATION];
+    }
+    
+	[super _initWithProperties:properties];
+    
+    [self setupPolygon];
+}
+
+
+#pragma mark Internal
+
+
+-(NSString*)apiName
+{
+    return @"Ti.Map.Polygon";
+}
+
+
+-(void)setupPolygon
+{
+    id points = [self valueForKey:@"points"];
+    CLLocationCoordinate2D* coordArray = malloc(sizeof(CLLocationCoordinate2D) * [points count]);
+    
+    for (int i = 0; i < [points count]; i++) {
+        id locObj = [points objectAtIndex:i];
+        CLLocationCoordinate2D coord = [self processLocation:locObj];
+        coordArray[i] = coord;
+    }
+    
+    id holes = [self valueForKey:@"holes"];
+    if (holes != nil && [holes count] > 0) {
+        // Holes is a 3-d array containing arrays of lng/lat pairings defining each hole or arrays of
+        // lat/lng objects defining each hole.
+        NSMutableArray *holePolygons = [NSMutableArray array];
+        for (int i=0; i < [holes count]; i++) {
+            id holeObj = [holes objectAtIndex:i];
+            CLLocationCoordinate2D* hole = malloc(sizeof(CLLocationCoordinate2D) * [holeObj count]);
+            
+            for (int j=0; j < [holeObj count]; ++j) {
+                id obj = [holeObj objectAtIndex:j];
+                CLLocationCoordinate2D coord = [self processLocation:obj];
+                hole[j] = coord;
+            }
+            
+            MKPolygon *interiorPolygon = [MKPolygon polygonWithCoordinates:hole count:[holeObj count]];
+            free(hole);
+            [holePolygons addObject:interiorPolygon];
+        }
+        
+        polygon = [[MKPolygon polygonWithCoordinates:coordArray count:[points count] interiorPolygons:holePolygons] retain];
+    } else {
+        polygon = [[MKPolygon polygonWithCoordinates:coordArray count:[points count]] retain];
+    }
+    
+    free(coordArray);
+    polygonRenderer = [[[MKPolygonRenderer alloc] initWithPolygon:polygon] retain];
+    
+    [self applyFillColor];
+    [self applyStrokeColor];
+    [self applyStrokeWidth];
+    
+}
+
+// A location can either be a an array of longitude, latitude pairings or
+// an array of longitude, latitude objects.
+// e.g. [ [123.33, 34.44], [100.39, 78.23], etc. ]
+// [ {longitude: 123.33, latitude, 34.44}, {longitude: 100.39, latitude: 78.23}, etc. ]
+-(CLLocationCoordinate2D)processLocation:(id)locObj
+{
+    CLLocationDegrees lat;
+    CLLocationDegrees lon;
+    CLLocationCoordinate2D coord;
+    
+    if ([locObj isKindOfClass:[NSDictionary class]]) {
+        lat = [TiUtils doubleValue:[locObj objectForKey:@"latitude"]];
+        lon = [TiUtils doubleValue:[locObj objectForKey:@"longitude"]];
+        coord = CLLocationCoordinate2DMake(lat, lon);
+    } else if ([locObj isKindOfClass:[NSArray class]]) {
+        lat = [TiUtils doubleValue:[locObj objectAtIndex:1]];
+        lon = [TiUtils doubleValue:[locObj objectAtIndex:0]];
+        coord = CLLocationCoordinate2DMake(lat, lon);
+    }
+    return coord;
+}
+
+-(void)applyFillColor
+{
+    if (polygonRenderer != nil) {
+         polygonRenderer.fillColor = fillColor == nil ? [UIColor blackColor] : [fillColor color];
+    }
+}
+
+-(void)applyStrokeColor
+{
+    if (polygonRenderer != nil) {
+        polygonRenderer.strokeColor = strokeColor == nil? [UIColor blackColor] : [strokeColor color];
+    }
+}
+
+-(void)applyStrokeWidth
+{
+    if (polygonRenderer != nil) {
+        polygonRenderer.lineWidth = strokeWidth;
+    }
+}
+
+#pragma mark Public APIs
+
+-(void)setPoints:(id)value
+{
+    ENSURE_TYPE(value, NSArray);
+    if (![value count]) {
+        [self throwException:@"missing required points data" subreason:nil location:CODELOCATION];
+    }
+    [self replaceValue:value forKey:@"points" notification:NO];
+}
+
+-(void)setFillColor:(id)value
+{
+    if (fillColor != nil) {
+        RELEASE_TO_NIL(fillColor);
+    }
+    fillColor = [[TiColor colorNamed:value] retain];
+    [self applyFillColor];
+}
+
+-(void)setStrokeColor:(id)value
+{
+    if (strokeColor != nil) {
+        RELEASE_TO_NIL(strokeColor);
+    }
+    strokeColor = [[TiColor colorNamed:value] retain];
+    [self applyStrokeColor];
+}
+
+-(void)setStrokeWidth:(id)value
+{
+    
+    strokeWidth = [TiUtils floatValue:value];
+    [self applyStrokeWidth];
+}
+
+
+
+@end

--- a/ios/Classes/TiMapView.h
+++ b/ios/Classes/TiMapView.h
@@ -1,4 +1,4 @@
-/**
+    /**
  * Appcelerator Titanium Mobile
  * Copyright (c) 2009-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
@@ -27,10 +27,12 @@
 	BOOL ignoreRegionChanged;
 	BOOL forceRender;
 	MKCoordinateRegion region;
+    NSMutableArray *polygonProxies;
+    
 	
     // routes
     // dictionaries for object tracking and association
-    CFMutableDictionaryRef mapLine2View;   // MKPolyline(route line) -> MKPolylineView(route view)    
+    CFMutableDictionaryRef mapObjects2View;   // MKOverlay Object -> MKOverlay Object's renderer    
 }
 
 @property (nonatomic, readonly) CLLocationDegrees longitudeDelta;
@@ -55,6 +57,11 @@
 -(void)addRoute:(id)args;
 -(void)removeRoute:(id)args;
 -(void)firePinChangeDragState:(MKAnnotationView *) pinview newState:(MKAnnotationViewDragState)newState fromOldState:(MKAnnotationViewDragState)oldState;
+-(void)addPolygon:(id)args;
+-(void)addPolygons:(id)args;
+-(void)removePolygon:(id)args;
+-(void)removePolygon:(id)args remove:(BOOL)r;
+-(void)removeAllPolygons;
 
 #pragma mark Utils
 -(void)addOverlay:(MKPolyline*)polyline level:(MKOverlayLevel)level;

--- a/ios/Classes/TiMapViewProxy.h
+++ b/ios/Classes/TiMapViewProxy.h
@@ -13,7 +13,9 @@
 	NSMutableArray* annotationsToAdd; // Annotations to add on initial display
 	NSMutableArray* annotationsToRemove; // Annotations to remove on initial display
 	NSMutableArray* routesToAdd; 
-	NSMutableArray* routesToRemove; 
+	NSMutableArray* routesToRemove;
+    NSMutableArray* polygonsToAdd;
+	NSMutableArray* polygonsToRemove;
 	int zoomCount; // Number of times to zoom in/out on initial display
 }
 
@@ -32,5 +34,8 @@
 -(void)zoom:(id)args;
 -(void)addRoute:(id)args;
 -(void)removeRoute:(id)args;
+-(void)addPolygon:(id)args;
+-(void)removePolygon:(id)args;
+-(void)removeAllPolygons:(id)args;
 
 @end

--- a/ios/Classes/TiMapViewProxy.m
+++ b/ios/Classes/TiMapViewProxy.m
@@ -9,6 +9,7 @@
 #import "TiMapView.h"
 #import "TiMapModule.h"
 #import "TiMapRouteProxy.h"
+#import "TiMapPolygonProxy.h"
 
 @implementation TiMapViewProxy
 
@@ -30,6 +31,8 @@
 	RELEASE_TO_NIL(annotationsToRemove);
 	RELEASE_TO_NIL(routesToAdd);
 	RELEASE_TO_NIL(routesToRemove);
+    RELEASE_TO_NIL(polygonsToAdd);
+	RELEASE_TO_NIL(polygonsToRemove);
 	[super _destroy];
 }
 
@@ -88,6 +91,16 @@
         [ourView removeRoute:arg];
     }
     
+    for (id arg in polygonsToAdd)
+    {
+        [ourView addPolygon:arg];
+    }
+    
+    for (id arg in polygonsToRemove)
+    {
+        [ourView removePolygon:arg];
+    }
+    
 	[ourView selectAnnotation:selectedAnnotation];
 	if (zoomCount > 0) {
 		for (int i=0; i < zoomCount; i++) {
@@ -105,6 +118,8 @@
 	RELEASE_TO_NIL(annotationsToRemove);
 	RELEASE_TO_NIL(routesToAdd);
 	RELEASE_TO_NIL(routesToRemove);
+    RELEASE_TO_NIL(polygonsToAdd);
+	RELEASE_TO_NIL(polygonsToRemove);
 	
 	[super viewDidAttach];
 }
@@ -408,6 +423,93 @@
 		}
 	}
 }
+
+-(void)addPolygon:(id)arg
+{
+	ENSURE_SINGLE_ARG(arg,TiMapPolygonProxy);
+    
+	if ([self viewAttached])
+	{
+		TiThreadPerformOnMainThread(^{[(TiMapView*)[self view] addPolygon:arg];}, NO);
+	}
+	else
+	{
+		if (polygonsToAdd==nil)
+		{
+			polygonsToAdd = [[NSMutableArray alloc] init];
+		}
+		if (polygonsToRemove!=nil && [polygonsToRemove containsObject:arg])
+		{
+			[polygonsToRemove removeObject:arg];
+		}
+		else
+		{
+			[polygonsToAdd addObject:arg];
+		}
+	}
+}
+
+-(void)removePolygon:(id)arg
+{
+	ENSURE_SINGLE_ARG(arg,TiMapPolygonProxy);
+    
+	if ([self viewAttached])
+	{
+		TiThreadPerformOnMainThread(^{[(TiMapView*)[self view] removePolygon:arg];}, NO);
+	}
+	else
+	{
+		if (polygonsToRemove==nil)
+		{
+			polygonsToRemove = [[NSMutableArray alloc] init];
+		}
+		if (polygonsToAdd!=nil && [polygonsToAdd containsObject:arg])
+		{
+			[polygonsToAdd removeObject:arg];
+		}
+		else
+		{
+			[polygonsToRemove addObject:arg];
+		}
+	}
+}
+
+-(void)removeAllPolygons:(id)args
+{
+    if ([self viewAttached])
+	{
+		TiThreadPerformOnMainThread(^{[(TiMapView*)[self view] removeAllPolygons];}, NO);
+	}
+}
+
+-(void)setPolygons:(id)arg{
+    ENSURE_TYPE(arg,NSArray);
+    
+    NSMutableArray* initialPolygons = [NSMutableArray arrayWithCapacity:[arg count]];
+    for (id poly in arg) {
+        ENSURE_TYPE(poly, TiMapPolygonProxy);
+        [initialPolygons addObject:poly];
+    }
+    
+    BOOL attached = [self viewAttached];
+ 
+    if(attached) {
+        TiThreadPerformOnMainThread(^{
+            [(TiMapView*)[self view] addPolygons:polygonsToAdd];
+        }, NO);
+        [initialPolygons release];
+    }
+    else {
+        RELEASE_TO_NIL(polygonsToAdd);
+        RELEASE_TO_NIL(polygonsToRemove);
+        
+        polygonsToAdd = [[NSMutableArray alloc] initWithArray:initialPolygons];
+    }
+}
+
+
+
+
 
 #pragma mark Public APIs iOS 7
 

--- a/ios/example/app.js
+++ b/ios/example/app.js
@@ -1,7 +1,7 @@
 
 /**
  * If the table view rows are too small on Android, add the following to your tiapp.xml
- * 
+ *
 <android xmlns:android="http://schemas.android.com/apk/res/android">
     <manifest>
         <supports-screens android:anyDensity="false"/>
@@ -34,11 +34,12 @@ var top = isIOS7Plus() ? 20 : 0;
 
 //=====================================================================
 // Rows
-//=====================================================================  
+//=====================================================================
 var rows = [
     require('tests/multiMap'),
     require('tests/annotations'),
-    require('tests/routes')
+    require('tests/routes'),
+    require('tests/polygons')
 ];
 
 if (IOS) {

--- a/ios/example/tests/polygons.js
+++ b/ios/example/tests/polygons.js
@@ -1,0 +1,109 @@
+
+exports.title = 'Polygons';
+exports.run = function(UI, Map) {
+    var win = UI.createWindow();
+
+    var rows = [
+        {
+            title: 'add poly1',
+            run: function(){
+                map.addPolygon(poly1);
+            }
+        },
+        {
+            title: 'rm poly1',
+            run: function(){
+                map.removePolygon(poly1);
+            }
+        },
+        {
+            title: 'rm all',
+            run: function(){
+                map.removeAllPolygons();
+            }
+        }
+    ];
+
+    var tableView = Ti.UI.createTableView({
+        top: '10%',
+        bottom: '50%',
+        data: rows
+    });
+    win.add(tableView);
+    tableView.addEventListener('click', function(e) {
+        rows[e.index].run && rows[e.index].run();
+    });
+
+    // Test points, holes, opacity, stroke width
+    var poly1 = Map.createPolygon({
+      points: [
+        {latitude: -33.855534, longitude: 151.200266},
+        {latitude: -33.859098, longitude: 151.230994},
+        {latitude: -33.877698, longitude: 151.225072},
+        {latitude: -33.875418, longitude: 151.201554}
+      ],
+      holes: [
+        [
+          {latitude: -33.870002, longitude: 151.210395},
+          [151.211939, -33.869503], // test array is valid
+          {latitude: -33.865940, longitude: 151.212540},
+          {latitude: -33.865084, longitude: 151.211682},
+          {latitude: -33.866439, longitude: 151.210738}
+        ],
+        [
+          {latitude: -33.858652, longitude: 151.204429},
+          {latitude: -33.858946, longitude: 151.205803},
+          {latitude: -33.860095, longitude: 151.205298},
+          {latitude: -33.860487, longitude: 151.204097},
+          {latitude: -33.859133, longitude: 151.204054}
+        ]
+      ],
+      fillColor: "rgba(237,5,42,0.75)",
+      strokeColor: "#912911",
+      strokeWidth: 2
+    }),
+
+    // Test counter-clockwise point definition, zIndex, points array
+    poly2 = Map.createPolygon({
+      points: [
+        [151.228290, -33.857280],
+        [151.224428, -33.855427],
+        [151.224170, -33.858991]
+      ],
+      fillColor: "#F2FA0C",
+      strokeColor: "#D4D93F",
+      strokeWidth: 2
+    }),
+
+    // Test zIndex
+    poly3 = Map.createPolygon({
+      points: [
+        {latitude: -33.854429, longitude: 151.214429},
+        {latitude: -33.854928, longitude: 151.236101},
+        {latitude: -33.866189, longitude: 151.232668}
+      ],
+      fillColor: "#5EB0DB",
+      strokeColor: "#00679E",
+      strokeWidth: 5
+    });
+
+
+
+    var map = Map.createView({
+        userLocation: true,
+        mapType: Map.NORMAL_TYPE,
+        animate: true,
+        polygons: [poly1, poly3, poly2],
+        region: {latitude: -33.87365, longitude: 151.20689, latitudeDelta:0.05, longitudeDelta:0.05}, //Sydney
+        top: '50%'
+    });
+    Ti.API.info("userLocation: " + map.userLocation);
+    win.add(map);
+
+    map.addEventListener('click', function(e) {
+        Ti.API.info("Latitude: " + e.latitude);
+        Ti.API.info("Source: " + e.clicksource);
+    });
+
+    win.open();
+};

--- a/ios/manifest
+++ b/ios/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 2.0.2
+version: 2.1.0
 apiversion: 2
 description: External version of Map module
 author: Jeff Haynie & Jon Alter


### PR DESCRIPTION
At Sitata, we've been experimenting with adding polygon support. Please check this out and let us know what you think. It could use a second look at things.
- Polygons can be specified on mapview creation.
- addPolygon, removePolygon, and removeAllPolygons methods.
- points can be specified as an object (verbose!) or as an array.
- version bump for both platforms.
