### PR TITLE
TIMOB-16180 renamed snapshot event to fit the scheme

### DIFF
--- a/android/src/ti/map/MapModule.java
+++ b/android/src/ti/map/MapModule.java
@@ -38,7 +38,7 @@ public class MapModule extends KrollModule
 	public static final String PROPERTY_ZOOM = "zoom";
 	public static final String PROPERTY_ZORDER_ON_TOP = "zOrderOnTop";
 	public static final String EVENT_PIN_CHANGE_DRAG_STATE = "pinchangedragstate";
-	public static final String EVENT_ON_SNAPSHOT_READY = "onsnapshotready";
+	public static final String EVENT_ON_SNAPSHOT_READY = "snapshotready";
 	
 	@Kroll.constant public static final int NORMAL_TYPE = GoogleMap.MAP_TYPE_NORMAL;
 	@Kroll.constant public static final int TERRAIN_TYPE = GoogleMap.MAP_TYPE_TERRAIN;

--- a/apidoc/View.yml
+++ b/apidoc/View.yml
@@ -164,7 +164,7 @@ methods:
   - name: snapshot
     summary: Takes a snapshot of the map
     description: |
-         Takes a snapshot of the current map and returns the image via [onsnapshotready](Modules.Map.View.onsnapshotready) event.
+         Takes a snapshot of the current map and returns the image via [snapshotready](Modules.Map.View.snapshotready) event.
     since: "3.2.3"
     platforms: [android]
 
@@ -202,7 +202,7 @@ methods:
 
 events:
     
-  - name: onsnapshotready
+  - name: snapshotready
     summary: Fired when the snapshot is ready after [snapshot](Modules.Map.View.snapshot) is invoked.
     properties:
     


### PR DESCRIPTION
removed the `on` -prefix to live up to the naming convention