### PR TITLE
Fix starting tag in module example.

### DIFF
--- a/apidoc/Map.yml
+++ b/apidoc/Map.yml
@@ -341,7 +341,7 @@ examples:
 
             <Alloy>
                 <Window>
-                    <View id="mapview" module="ti.map" onClick="report">
+                    <Module id="mapview" module="ti.map" onClick="report">
                         <!-- Starting with Alloy 1.4.0, use the Annotation tag to define an annotation -->
                         <!-- Prior to Alloy 1.4.0, create annotations in the controller -->
                         <Annotation id='appcHQ' myid='1' />


### PR DESCRIPTION
Example started with a View tag and ended with a closing Module tag.
Updated to open and close with a Module tag.