### PR TITLE
[TIDOC-2202] Typo in Maps Example

### DIFF
--- a/apidoc/Map.yml
+++ b/apidoc/Map.yml
@@ -345,7 +345,7 @@ examples:
                         <!-- Starting with Alloy 1.4.0, use the Annotation tag to define an annotation -->
                         <!-- Prior to Alloy 1.4.0, create annotations in the controller -->
                         <Annotation id='appcHQ' myid='1' />
-                    </Module>
+                    </View>
                 </Window>
             </Alloy>
 


### PR DESCRIPTION
Opened as `<View>` but closed as `</Module>`

https://jira.appcelerator.org/browse/TIDOC-2202