### PR TITLE
Fixed broken page (TIDOC-2450)

### DIFF
--- a/apidoc/Map.yml
+++ b/apidoc/Map.yml
@@ -359,8 +359,7 @@ examples:
                 Ti.API.info("Clicked " + evt.clicksource + " on " + evt.latitude + "," + evt.longitude);
             });
             win.open();
-
-examples:
+            
   - title: Alloy XML Markup
     example: |
         Previous example as an Alloy view.

--- a/apidoc/Map.yml
+++ b/apidoc/Map.yml
@@ -313,6 +313,7 @@ methods:
     platforms: [android]
 
 examples:
+
   - title: Map Example
     example: |
         This is a basic map example that places a custom annotation on the map, and

--- a/apidoc/Map.yml
+++ b/apidoc/Map.yml
@@ -360,6 +360,7 @@ examples:
             });
             win.open();
 
+examples:
   - title: Alloy XML Markup
     example: |
         Previous example as an Alloy view.
@@ -414,4 +415,3 @@ examples:
             }
 
             $.index.open();
-

--- a/apidoc/StreetViewPanorama.yml
+++ b/apidoc/StreetViewPanorama.yml
@@ -1,51 +1,58 @@
---- 
+---
+name: Modules.Map.StreetViewPanorama
+summary: Provides panoramic 360-degree views from designated roads throughout its coverage area.
 description: |
     Each street view panorama is an image, or set of images, that provides a full 360-degree view from
     a single location. It provides a viewer that renders the panorama as a sphere with a camera at its center.
     A window can only contain one street view.
-excludes: 
-  events: 
-    - singletap
-    - doubletap
-    - dblclick
-    - longpress
-    - pinch
-    - swipe
-    - touchstart
-    - touchend
-    - touchcancel
-    - touchmove
-    - twofingertap
+
 extends: Titanium.UI.View
-name: Modules.Map.StreetViewPanorama
-platforms: 
-  - android
-properties: 
-  - 
-    name: position
-    summary: "A dictionary specifying the position of the street view."
-    type: StreetViewPosition
-  - 
-    default: true
-    name: panning
-    summary: "Determines whether the user is able to re-orient the camera by dragging."
-    type: Boolean
-  - 
-    default: true
-    name: zoom
-    summary: "Determines whether the user is able to pinch to zoom."
-    type: Boolean
-  - 
-    default: true
-    name: streetNames
-    summary: "Determines whether the user is able to see street names displayed."
-    type: Boolean
-  - 
-    default: true
-    description: "If `true`, users can use a single tap on navigation links, or double tap the\n\
-        view, to move to a new panorama.    \n"
-    name: userNavigation
-    summary: "Determines whether the user is able to move to a different panorama."
-    type: Boolean
+excludes:
+    events: [ 'singletap', 'doubletap', 'dblclick', 'longpress', 'pinch',
+              'swipe', 'touchstart', 'touchend', 'touchcancel', 'touchmove', 'twofingertap' ]
+
 since: "5.2.0"
-summary: "Provides panoramic 360-degree views from designated roads throughout its coverage area."
+platforms: [android]
+properties:
+
+  - name: position
+    summary: A dictionary specifying the position of the street view.
+    type: StreetViewPosition
+
+  - name: panning
+    summary: Determines whether the user is able to re-orient the camera by dragging.
+    type: Boolean
+    default: true
+
+  - name: zoom
+    summary: Determines whether the user is able to pinch to zoom.
+    type: Boolean
+    default: true
+
+  - name: streetNames
+    summary: Determines whether the user is able to see street names displayed.
+    type: Boolean
+    default: true
+
+  - name: userNavigation
+    summary: Determines whether the user is able to move to a different panorama.
+    description: |
+        If `true`, users can use a single tap on navigation links, or double tap the
+        view, to move to a new panorama.    
+    type: Boolean
+    default: true
+---
+name: StreetViewPosition
+summary: Simple object representing a street view coordinates.
+properties:
+
+  - name: longitude
+    summary: Longitude value for the center point of the view, in decimal degrees.
+    type: Number
+    default: 0
+
+  - name: latitude
+    summary: Latitude value for the center point of the view, in decimal degrees.
+    type: Number
+    default: 0
+since: "5.2.0"

--- a/apidoc/StreetViewPanorama.yml
+++ b/apidoc/StreetViewPanorama.yml
@@ -1,59 +1,51 @@
----
-name: Modules.Map.StreetViewPanorama
-summary: Provides panoramic 360-degree views from designated roads throughout its coverage area.
+--- 
 description: |
     Each street view panorama is an image, or set of images, that provides a full 360-degree view from
     a single location. It provides a viewer that renders the panorama as a sphere with a camera at its center.
     A window can only contain one street view.
-
+excludes: 
+  events: 
+    - singletap
+    - doubletap
+    - dblclick
+    - longpress
+    - pinch
+    - swipe
+    - touchstart
+    - touchend
+    - touchcancel
+    - touchmove
+    - twofingertap
 extends: Titanium.UI.View
-excludes:
-    events: [ 'singletap', 'doubletap', 'dblclick', 'longpress', 'pinch',
-              'swipe', 'touchstart', 'touchend', 'touchcancel', 'touchmove', 'twofingertap' ]
-
-since:"5.2.0"
-platforms: [android]
-properties:
-
-  - name: position
-    summary: A dictionary specifying the position of the street view.
+name: Modules.Map.StreetViewPanorama
+platforms: 
+  - android
+properties: 
+  - 
+    name: position
+    summary: "A dictionary specifying the position of the street view."
     type: StreetViewPosition
-
-  - name: panning
-    summary: Determines whether the user is able to re-orient the camera by dragging.
-    type: Boolean
+  - 
     default: true
-
-  - name: zoom
-    summary: Determines whether the user is able to pinch to zoom.
+    name: panning
+    summary: "Determines whether the user is able to re-orient the camera by dragging."
     type: Boolean
+  - 
     default: true
-
-  - name: streetNames
-    summary: Determines whether the user is able to see street names displayed.
+    name: zoom
+    summary: "Determines whether the user is able to pinch to zoom."
     type: Boolean
+  - 
     default: true
-
-  - name: userNavigation
-    summary: Determines whether the user is able to move to a different panorama.
-    description: |
-        If `true`, users can use a single tap on navigation links, or double tap the
-        view, to move to a new panorama.    
+    name: streetNames
+    summary: "Determines whether the user is able to see street names displayed."
     type: Boolean
+  - 
     default: true
----
-name: StreetViewPosition
-summary: Simple object representing a street view coordinates.
-properties:
-
-  - name: longitude
-    summary: Longitude value for the center point of the view, in decimal degrees.
-    type: Number
-    default: 0
-
-  - name: latitude
-    summary: Latitude value for the center point of the view, in decimal degrees.
-    type: Number
-    default: 0
+    description: "If `true`, users can use a single tap on navigation links, or double tap the\n\
+        view, to move to a new panorama.    \n"
+    name: userNavigation
+    summary: "Determines whether the user is able to move to a different panorama."
+    type: Boolean
 since: "5.2.0"
-
+summary: "Provides panoramic 360-degree views from designated roads throughout its coverage area."


### PR DESCRIPTION
At the end of the Map.yml file, there are two example. The last example
doesn’t have an “examples” header which was causing the valid yaml to
treat the last example as a method (which passes the validation test)
but results in rendering no content. With the additional insertion of
examples:﻿ on line 363 of Map.yml, the content shows up again.