### PR TITLE
Bug Fix: regionchanged and regionwillchange returned animated was always true

### DIFF
--- a/ios/Classes/TiMapView.m
+++ b/ios/Classes/TiMapView.m
@@ -782,7 +782,7 @@
     }
     
     if ([[self proxy] _hasListeners:@"regionwillchange"]) {
-        [self fireEvent:@"regionwillchange" withRegion:region animated:animate];
+        [self fireEvent:@"regionwillchange" withRegion:region animated:animated];
     }
 }
 
@@ -796,11 +796,11 @@
 	
     if ([self.proxy _hasListeners:@"regionChanged"]) {
         NSLog(@"[WARN] The 'regionChanged' event is deprecated, use 'regionchanged' instead.");
-        [self fireEvent:@"regionChanged" withRegion:[mapView region] animated:animate];
+        [self fireEvent:@"regionChanged" withRegion:[mapView region] animated:animated];
 	}
     
 	if ([self.proxy _hasListeners:@"regionchanged"]) {
-        [self fireEvent:@"regionchanged" withRegion:[mapView region] animated:animate];
+        [self fireEvent:@"regionchanged" withRegion:[mapView region] animated:animated];
 	}
 }
 


### PR DESCRIPTION
Fix to returned property animated. Was always returning true.
The fix includes (and should be): If the User pans with their finger
the map, the animated property returns false, if you animate the map
programatically it returns true.