### PR TITLE
[MOD-2344] iOS: Fix bug where MKMapView wasnt drawing polygon overlays in some cases

### DIFF
--- a/ios/Classes/TiMapView.m
+++ b/ios/Classes/TiMapView.m
@@ -580,6 +580,11 @@
             polygonProxies = [[NSMutableArray alloc] init];
         }
         [polygonProxies addObject:polygonProxy];
+
+        // NOTE: this is intended to fix a bug where MKMapView doesnt call
+        // through to [MKOverlayRenderer canDrawMapRect:zoomScale:] until a user
+        // moves the map
+        map.camera.centerCoordinate = map.camera.centerCoordinate;
     }, NO);
 }
 


### PR DESCRIPTION
Hi, thanks for the module!

I ran into a situation where a convoluted set of user actions on iOS (device rotation, textfield focus/blur, tab swapping) ended up getting the MKMapView into a state where if I called `mapView.addPolygons` from the JS, they wouldn't actually render until the map was zoomed or panned.

This was the only successful workaround I could find. I also tried posting different combinations of `setNeedsDisplay`,  `invalidatePath`, and `setNeedsLayout` on both the current and main queue for the mapview as well as the overlay renderer.

That said, it was a tough bug to reproduce so its possible that this doesnt actually fix things in the end.

**JIRA**: https://jira.appcelerator.org/browse/MOD-2344