### PR TITLE
[MOD-2334] Android: Fix userLocation crash when permissions are not set

### DIFF
--- a/android/documentation/changelog.md
+++ b/android/documentation/changelog.md
@@ -1,5 +1,6 @@
 # Change Log
 <pre>
+v3.1.3    Android: Fix userLocation crash [MOD-2334]
 v3.1.2    Android: Fix removeAnnotation [MOD-2337]
 v3.1.1    Android: Fix Annotation memory leak [TIMOB-23269]
 v3.1.0    Android: Add style property [MOD-2311]

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 3.1.2
+version: 3.1.3
 apiversion: 3
 architectures: armeabi-v7a x86
 description: External version of Map module to support new Google Map v2 sdk

--- a/android/src/ti/map/TiUIMapView.java
+++ b/android/src/ti/map/TiUIMapView.java
@@ -18,6 +18,7 @@ import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.util.TiConvert;
 import org.appcelerator.titanium.view.TiUIFragment;
+import org.appcelerator.titanium.TiApplication;
 
 import ti.map.Shape.Boundary;
 import ti.map.Shape.IShape;
@@ -34,6 +35,10 @@ import android.view.SurfaceView;
 import android.view.View;
 import android.view.ViewGroup;
 import android.content.res.Resources;
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.Manifest;
+
 
 import com.google.android.gms.maps.CameraUpdate;
 import com.google.android.gms.maps.CameraUpdateFactory;
@@ -299,7 +304,12 @@ public class TiUIMapView extends TiUIFragment implements GoogleMap.OnMarkerClick
 	}
 
 	protected void setUserLocationEnabled(boolean enabled) {
-		map.setMyLocationEnabled(enabled);
+		Context context = TiApplication.getInstance().getApplicationContext();
+		if (Build.VERSION.SDK_INT < 23 || context.checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED) {
+			map.setMyLocationEnabled(enabled);
+		} else {
+			Log.e(TAG, "Enable ACCESS_FINE_LOCATION permission to use userLocation");
+		}
 	}
 
 	protected void setCompassEnabled(boolean enabled) {


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/MOD-2334
A MapView with userLocation:true in TSS will crash the app if you don't allow the Android M ACCESS_FINE_LOCATION.

