### PR TITLE
[TIMOB-25288] Bump to 3.3.1

### DIFF
--- a/android/documentation/changelog.md
+++ b/android/documentation/changelog.md
@@ -1,5 +1,6 @@
 # Change Log
 <pre>
+v3.3.1    Compile using 6.2.0.GA [TIMOB-25288]
 v3.3.0    Expose "regionwillchange" event for iOS-parity [MOD-2343]
 v3.2.0    Support for overlay patterns [MOD-2346]
 v3.1.3    Fix Android "userLocation" crash [MOD-2334]

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 3.3.0
+version: 3.3.1
 apiversion: 3
 architectures: armeabi-v7a x86
 description: External version of Map module to support new Google Map v2 sdk


### PR DESCRIPTION
- Bump to `3.3.1`
- [android-3.3.1](https://github.com/appcelerator-modules/ti.map/releases/tag/android-3.3.1) built using `6.2.0.GA`