### PR TITLE
[MOD-2401] Ti.Map: Inconsistency between iOS and Android click events on Annotations

### DIFF
--- a/android/src/ti/map/MapModule.java
+++ b/android/src/ti/map/MapModule.java
@@ -20,11 +20,15 @@ import com.google.android.gms.maps.model.BitmapDescriptorFactory;
 @Kroll.module(name = "Map", id = "ti.map")
 public class MapModule extends KrollModule
 {
+	public static final String EVENT_MAP_CLICK = "mapclick";
+	public static final String EVENT_PIN_CHANGE_DRAG_STATE = "pinchangedragstate";
+	public static final String EVENT_ON_SNAPSHOT_READY = "onsnapshotready";
+	public static final String EVENT_REGION_WILL_CHANGE = "regionwillchange";
+
 	public static final String PROPERTY_DRAGGABLE = "draggable";
 	public static final String PROPERTY_POINTS = "points";
 	public static final String PROPERTY_TRAFFIC = "traffic";
 	public static final String PROPERTY_MAP = "map";
-	public static final String PROPERTY_MAP_CLICK = "mapclick";
 	public static final String PROPERTY_SHAPE = "shape";
 	public static final String PROPERTY_SHAPE_TYPE = "shapeType";
 	public static final String PROPERTY_NEWSTATE = "newState";
@@ -48,9 +52,6 @@ public class MapModule extends KrollModule
 	public static final String PROPERTY_USER_NAVIGATION = "userNavigation";
 	public static final String PROPERTY_HIDDEN = "hidden";
 	public static final String PROPERTY_CLUSTER_IDENTIFIER = "clusterIdentifier";
-	public static final String EVENT_PIN_CHANGE_DRAG_STATE = "pinchangedragstate";
-	public static final String EVENT_ON_SNAPSHOT_READY = "onsnapshotready";
-	public static final String EVENT_REGION_WILL_CHANGE = "regionwillchange";
 
 	public static final String PROPERTY_STROKE_COLOR = "strokeColor";
 	public static final String PROPERTY_STROKE_WIDTH = "strokeWidth";

--- a/android/src/ti/map/TiUIMapView.java
+++ b/android/src/ti/map/TiUIMapView.java
@@ -913,11 +913,23 @@ public class TiUIMapView extends TiUIFragment
 		if (annoProxy == null) {
 			Log.e(TAG, "Marker can not be found, click event won't fired.", Log.DEBUG_MODE);
 			return false;
-		} else if (selectedAnnotation != null && selectedAnnotation.equals(annoProxy)) {
+		}
+		if (selectedAnnotation != null) {
 			selectedAnnotation.hideInfo();
-			selectedAnnotation = null;
-			fireClickEvent(marker, annoProxy, MapModule.PROPERTY_PIN);
-			return true;
+			// Clicking on the selected annotation again.
+			// After hiding the info window, send deselected
+			// event and return from this listener.
+			if (selectedAnnotation.equals(annoProxy)) {
+				selectedAnnotation = null;
+				fireClickEvent(marker, annoProxy, MapModule.PROPERTY_PIN);
+				return true;
+			} else {
+				// Clicking from a selected annotation to another one.
+				// After hiding the info window, send deselected
+				// event for the selected annotation and proceed with
+				// this listener for the marker parameter.
+				fireClickEvent(marker, selectedAnnotation, MapModule.PROPERTY_PIN);
+			}
 		}
 		fireClickEvent(marker, annoProxy, MapModule.PROPERTY_PIN);
 		selectedAnnotation = annoProxy;
@@ -1022,7 +1034,7 @@ public class TiUIMapView extends TiUIFragment
 		d.put(TiC.PROPERTY_LATITUDE, point.latitude);
 		d.put(TiC.PROPERTY_LONGITUDE, point.longitude);
 		d.put(MapModule.PROPERTY_MAP, proxy);
-		proxy.fireEvent(MapModule.PROPERTY_MAP_CLICK, d);
+		proxy.fireEvent(MapModule.EVENT_MAP_CLICK, d);
 	}
 
 	@Override


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/MOD-2401

**Description:**
Add a click event for deselecting annotations when clicking directly on another one.

**Note:** I am OK with implementing it this way for parity's sake, but I think such an event may be better suited not as a `click` one. For both platforms. IMO selecting/deselecting an annotation may be originating not only from a click, but for instance from `Modules.Map.View.selectAnnotation()`. So it makes sense to me to have a `click` event and a `select` event that get naturally combined when one is the cause of the other. We can consider that for a future major version of the module maybe?

CC: @hansemannn, @jquick-axway, @Topener  

**Test case:**
In the JIRA ticket.