### PR TITLE
[MOD-2457] Android: Expose setIndoorEnabled API for Ti.Map

### DIFF
--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 4.3.1
+version: 4.3.2
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86
 description: External version of Map module to support new Google Map v2 sdk

--- a/android/src/ti/map/MapModule.java
+++ b/android/src/ti/map/MapModule.java
@@ -67,6 +67,8 @@ public class MapModule extends KrollModule
 	public static final String PROPERTY_CENTER = "center";
 	public static final String PROPERTY_RADIUS = "radius";
 
+	public static final String PROPERTY_INDOOR_ENABLED = "indoorEnabled";
+
 	@Kroll.constant
 	public static final int NORMAL_TYPE = GoogleMap.MAP_TYPE_NORMAL;
 	@Kroll.constant

--- a/android/src/ti/map/TiUIMapView.java
+++ b/android/src/ti/map/TiUIMapView.java
@@ -87,6 +87,7 @@ public class TiUIMapView extends TiUIFragment
 		currentPolygons = new ArrayList<PolygonProxy>();
 		currentPolylines = new ArrayList<PolylineProxy>();
 		currentImageOverlays = new ArrayList<ImageOverlayProxy>();
+		proxy.setProperty(MapModule.PROPERTY_INDOOR_ENABLED, true);
 	}
 
 	/**
@@ -280,6 +281,9 @@ public class TiUIMapView extends TiUIFragment
 		if (d.containsKey(TiC.PROPERTY_STYLE)) {
 			setStyle(d.getString(TiC.PROPERTY_STYLE));
 		}
+		if (d.containsKey(MapModule.PROPERTY_INDOOR_ENABLED)) {
+			setIndoorEnabled(d.getBoolean(MapModule.PROPERTY_INDOOR_ENABLED));
+		}
 	}
 
 	@Override
@@ -312,6 +316,8 @@ public class TiUIMapView extends TiUIFragment
 			setZoomControlsEnabled(TiConvert.toBoolean(newValue, true));
 		} else if (key.equals(TiC.PROPERTY_STYLE)) {
 			setStyle(TiConvert.toString(newValue, ""));
+		} else if (key.equals(MapModule.PROPERTY_INDOOR_ENABLED)) {
+			setIndoorEnabled(TiConvert.toBoolean(newValue, true));
 		} else {
 			super.propertyChanged(key, oldValue, newValue, proxy);
 		}
@@ -354,6 +360,13 @@ public class TiUIMapView extends TiUIFragment
 	{
 		if (map != null) {
 			map.getUiSettings().setCompassEnabled(enabled);
+		}
+	}
+
+	protected void setIndoorEnabled(boolean enabled)
+	{
+		if (map != null) {
+			map.setIndoorEnabled(enabled);
 		}
 	}
 

--- a/apidoc/View.yml
+++ b/apidoc/View.yml
@@ -826,7 +826,18 @@ properties:
     default: true
     since: "7.2.0"
     platforms: [iphone, ipad]
-    
+
+  - name: indoorEnabled
+    summary: A Boolean value indicating whether the indoor mapping is enabled.
+    description: |
+        This property is used to enabled/disable the indoor mapping feature of Google Maps.
+        Changing the value after the MapView is drawn can cause flickering. 
+        You can read more at:
+        [Google Indoor Maps](https://www.google.com/maps/about/partners/indoormaps/)
+    type: Boolean
+    default: true
+    since: "7.5.0"
+    platforms: [android]
 ---
 name: MapViewPadding
 summary: The padding applied to the map view using <Modules.Map.View.padding>.


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/MOD-2457

**Description:**
Expose `setIndoorEnabled()` API for Ti.Map on Android.

**Note:** I'd prefer we clear v4.3.1 of the module from possible issues and add this feature in the following version. Possibly together with Titanium 7.5.0. 

**Test case:** 
app.js
```js
var Map = require('ti.map'),
    win = Ti.UI.createWindow(),
    mapView = Map.createView({ region: {
      longitude:  -73.993389,
      latitude: 40.750389,
      latitudeDelta: 0.002,
      longitudeDelta: 0.002 }
    }),
    button = Ti.UI.createButton({ bottom: 10,
      title: 'Indoor map - enabled'
    });

button.addEventListener('click', function () {
  mapView.indoorEnabled = !mapView.indoorEnabled;
  button.title = mapView.indoorEnabled ? 'Indoor map - enabled' : 'Indoor map - disabled';
});

mapView.addEventListener('complete', function () {
  mapView.add(button);
});

win.add(mapView);
win.open();
```