### PR TITLE
[MOD-2458] Android Ti.Maps removing annotation issues 4.3.0 with clusters

### DIFF
--- a/android/src/ti/map/TiUIMapView.java
+++ b/android/src/ti/map/TiUIMapView.java
@@ -522,6 +522,7 @@ public class TiUIMapView extends TiUIFragment
 				if (mClusterManager != null) {
 					mClusterManager.addItem((TiMarker)tiMarker);
 				}
+				mClusterManager.cluster();
 			}
 			annotation.setTiMarker(tiMarker);
 			timarkers.add(tiMarker);
@@ -552,14 +553,17 @@ public class TiUIMapView extends TiUIFragment
 		// clear normal markers
 		for (int i = 0; i < timarkers.size(); i++) {
 			TiMarker timarker = timarkers.get(i);
-			timarker.getMarker().remove();
-			timarker.release();
+			if (timarker.getMarker() != null) {
+				timarker.getMarker().remove();
+				timarker.release();
+			}
 		}
 		timarkers.clear();
 
 		// clear cluster markers
 		if (mClusterManager != null) {
 			mClusterManager.clearItems();
+			mClusterManager.cluster();
 		}
 	}
 
@@ -585,10 +589,16 @@ public class TiUIMapView extends TiUIFragment
 		} else if (annotation instanceof String) {
 			timarker = findMarkerByTitle((String) annotation);
 		}
-		if (timarker != null) {
+		if (timarker != null && timarkers.contains(timarker)) {
+			if (mClusterManager != null) {
+				mClusterManager.removeItem(timarker);
+				mClusterManager.cluster();
+			}
+			if (timarker.getMarker() != null) {
+				timarker.getMarker().remove();
+				timarker.release();
+			}
 			timarkers.remove(timarker);
-			timarker.getMarker().remove();
-			timarker.release();
 		}
 	}
 

--- a/android/src/ti/map/TiUIMapView.java
+++ b/android/src/ti/map/TiUIMapView.java
@@ -521,8 +521,8 @@ public class TiUIMapView extends TiUIFragment
 				tiMarker = new TiMarker(null, annotation);	
 				if (mClusterManager != null) {
 					mClusterManager.addItem((TiMarker)tiMarker);
+					mClusterManager.cluster();
 				}
-				mClusterManager.cluster();
 			}
 			annotation.setTiMarker(tiMarker);
 			timarkers.add(tiMarker);
@@ -555,8 +555,8 @@ public class TiUIMapView extends TiUIFragment
 			TiMarker timarker = timarkers.get(i);
 			if (timarker.getMarker() != null) {
 				timarker.getMarker().remove();
-				timarker.release();
 			}
+			timarker.release();
 		}
 		timarkers.clear();
 
@@ -596,8 +596,8 @@ public class TiUIMapView extends TiUIFragment
 			}
 			if (timarker.getMarker() != null) {
 				timarker.getMarker().remove();
-				timarker.release();
 			}
+			timarker.release();
 			timarkers.remove(timarker);
 		}
 	}


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/MOD-2458

**Description:**
Fix removing of annotations when clustering is enabled.
Fix updating the map when annotations are added/removed with clustering enabled.

**Note:** I haven't updated the manifest, because I think we can put it together with this PR (https://github.com/appcelerator-modules/ti.map/pull/244) for 4.3.2

**Test case:**
There is a good test case in the JIRA tickets.