### PR TITLE
feat: add deselected parameter in click event

### DIFF
--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 4.4.0
+version: 4.5.0
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86
 description: External version of Map module to support new Google Map v2 sdk

--- a/android/src/ti/map/MapModule.java
+++ b/android/src/ti/map/MapModule.java
@@ -68,6 +68,7 @@ public class MapModule extends KrollModule
 	public static final String PROPERTY_CENTER = "center";
 	public static final String PROPERTY_RADIUS = "radius";
 	public static final String PROPERTY_INDOOR_ENABLED = "indoorEnabled";
+	public static final String PROPERTY_DESELECTED = "deselected";
 
 	@Kroll.constant
 	public static final int NORMAL_TYPE = GoogleMap.MAP_TYPE_NORMAL;

--- a/android/src/ti/map/TiUIMapView.java
+++ b/android/src/ti/map/TiUIMapView.java
@@ -7,33 +7,11 @@
 
 package ti.map;
 
-import org.json.JSONObject;
-import org.json.JSONArray;
-import org.json.JSONTokener;
-
-import org.json.JSONException;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.io.ByteArrayOutputStream;
-
-import org.appcelerator.kroll.KrollDict;
-import org.appcelerator.kroll.KrollProxy;
-import org.appcelerator.kroll.common.Log;
-import org.appcelerator.titanium.TiBlob;
-import org.appcelerator.titanium.TiC;
-import org.appcelerator.titanium.proxy.TiViewProxy;
-import org.appcelerator.titanium.util.TiConvert;
-import org.appcelerator.titanium.view.TiUIFragment;
-import org.appcelerator.titanium.TiApplication;
-import org.appcelerator.titanium.io.TiFileFactory;
-
-import ti.map.Shape.Boundary;
-import ti.map.Shape.IShape;
-import ti.map.Shape.PolylineBoundary;
+import android.Manifest;
 import android.app.Activity;
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.graphics.Point;
@@ -44,11 +22,6 @@ import android.view.MotionEvent;
 import android.view.SurfaceView;
 import android.view.View;
 import android.view.ViewGroup;
-import android.content.res.Resources;
-import android.content.Context;
-import android.content.pm.PackageManager;
-import android.Manifest;
-
 import com.google.android.gms.maps.CameraUpdate;
 import com.google.android.gms.maps.CameraUpdateFactory;
 import com.google.android.gms.maps.GoogleMap;
@@ -59,11 +32,34 @@ import com.google.android.gms.maps.model.CameraPosition;
 import com.google.android.gms.maps.model.Circle;
 import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.LatLngBounds;
-import com.google.android.gms.maps.model.Marker;
 import com.google.android.gms.maps.model.MapStyleOptions;
+import com.google.android.gms.maps.model.Marker;
 import com.google.maps.android.MarkerManager;
-import com.google.maps.android.clustering.ClusterManager;
 import com.google.maps.android.clustering.Cluster;
+import com.google.maps.android.clustering.ClusterManager;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import org.appcelerator.kroll.KrollDict;
+import org.appcelerator.kroll.KrollProxy;
+import org.appcelerator.kroll.annotations.Kroll;
+import org.appcelerator.kroll.common.Log;
+import org.appcelerator.titanium.TiApplication;
+import org.appcelerator.titanium.TiBlob;
+import org.appcelerator.titanium.TiC;
+import org.appcelerator.titanium.io.TiFileFactory;
+import org.appcelerator.titanium.proxy.TiViewProxy;
+import org.appcelerator.titanium.util.TiConvert;
+import org.appcelerator.titanium.view.TiUIFragment;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.json.JSONTokener;
+import ti.map.Shape.Boundary;
+import ti.map.Shape.IShape;
+import ti.map.Shape.PolylineBoundary;
 
 public class TiUIMapView extends TiUIFragment
 	implements GoogleMap.OnMarkerClickListener, GoogleMap.OnMapClickListener, GoogleMap.OnMarkerDragListener,
@@ -359,9 +355,9 @@ public class TiUIMapView extends TiUIFragment
 					Object json = new JSONTokener(loadJSONFromAsset(style)).nextValue();
 
 					if (json instanceof JSONObject) {
-						style = ((JSONObject)json).toString();
+						style = ((JSONObject) json).toString();
 					} else if (json instanceof JSONArray) {
-						style = ((JSONArray)json).toString();
+						style = ((JSONArray) json).toString();
 					} else {
 						Log.e(TAG, "Invalid JSON style.");
 					}
@@ -460,7 +456,8 @@ public class TiUIMapView extends TiUIFragment
 		}
 	}
 
-	protected void showAnnotations(Object[] annotations) {
+	protected void showAnnotations(Object[] annotations)
+	{
 		ArrayList<TiMarker> markers = new ArrayList<TiMarker>();
 
 		// Use supplied annotations first. If none available, select all (parity with iOS)
@@ -957,7 +954,7 @@ public class TiUIMapView extends TiUIFragment
 		}
 	}
 
-	public void fireClickEvent(Marker marker, AnnotationProxy annoProxy, String clickSource)
+	public void fireClickEvent(Marker marker, AnnotationProxy annoProxy, String clickSource, boolean deselected)
 	{
 		KrollDict d = new KrollDict();
 		String title = null;
@@ -976,6 +973,7 @@ public class TiUIMapView extends TiUIFragment
 		d.put(TiC.PROPERTY_TYPE, TiC.EVENT_CLICK);
 		d.put(TiC.PROPERTY_SOURCE, proxy);
 		d.put(TiC.EVENT_PROPERTY_CLICKSOURCE, clickSource);
+		d.put(MapModule.PROPERTY_DESELECTED, deselected);
 		if (proxy != null) {
 			proxy.fireEvent(TiC.EVENT_CLICK, d);
 		}
@@ -1053,17 +1051,17 @@ public class TiUIMapView extends TiUIFragment
 			// event and return from this listener.
 			if (selectedAnnotation.equals(annoProxy)) {
 				selectedAnnotation = null;
-				fireClickEvent(marker, annoProxy, MapModule.PROPERTY_PIN);
+				fireClickEvent(marker, annoProxy, MapModule.PROPERTY_PIN, true);
 				return true;
 			} else {
 				// Clicking from a selected annotation to another one.
 				// After hiding the info window, send deselected
 				// event for the selected annotation and proceed with
 				// this listener for the marker parameter.
-				fireClickEvent(marker, selectedAnnotation, MapModule.PROPERTY_PIN);
+				fireClickEvent(marker, selectedAnnotation, MapModule.PROPERTY_PIN, true);
 			}
 		}
-		fireClickEvent(marker, annoProxy, MapModule.PROPERTY_PIN);
+		fireClickEvent(marker, annoProxy, MapModule.PROPERTY_PIN, false);
 		selectedAnnotation = annoProxy;
 		boolean showInfoWindow = TiConvert.toBoolean(annoProxy.getProperty(MapModule.PROPERTY_SHOW_INFO_WINDOW), true);
 		// Returning false here will enable native behavior, which shows the
@@ -1081,7 +1079,7 @@ public class TiUIMapView extends TiUIFragment
 		if (selectedAnnotation != null) {
 			TiMarker tiMarker = selectedAnnotation.getTiMarker();
 			if (tiMarker != null) {
-				fireClickEvent(tiMarker.getMarker(), selectedAnnotation, null);
+				fireClickEvent(tiMarker.getMarker(), selectedAnnotation, null, true);
 			}
 			selectedAnnotation = null;
 		}
@@ -1219,7 +1217,7 @@ public class TiUIMapView extends TiUIFragment
 			if (clicksource == null) {
 				clicksource = MapModule.PROPERTY_INFO_WINDOW;
 			}
-			fireClickEvent(marker, annoProxy, clicksource);
+			fireClickEvent(marker, annoProxy, clicksource, false);
 		}
 	}
 

--- a/apidoc/View.yml
+++ b/apidoc/View.yml
@@ -446,6 +446,13 @@ events:
             Longitude of the clicked annotation or the point clicked in the polygon, polyline and circle.
         type: Number
 
+      - name: deselected
+        summary: |
+            Will show if the annotation was selected (false) or deselected (true)
+        type: Boolean
+        since: "4.5.0"
+        platforms: [android]
+
   - name: complete
     summary: Fired when the map completes loading.
 
@@ -848,7 +855,7 @@ properties:
     summary: A Boolean value indicating whether the indoor mapping is enabled.
     description: |
         This property is used to enabled/disable the indoor mapping feature of Google Maps.
-        Changing the value after the MapView is drawn can cause flickering. 
+        Changing the value after the MapView is drawn can cause flickering.
         You can read more at:
         [Google Indoor Maps](https://www.google.com/maps/about/partners/indoormaps/)
     type: Boolean

--- a/apidoc/View.yml
+++ b/apidoc/View.yml
@@ -451,7 +451,7 @@ events:
             Will show if the annotation was selected (false) or deselected (true)
         type: Boolean
         since: "4.5.0"
-        platforms: [android]
+        platforms: [android, iphone, ipad]
 
   - name: complete
     summary: Fired when the map completes loading.

--- a/ios/Classes/TiMapView.h
+++ b/ios/Classes/TiMapView.h
@@ -104,6 +104,6 @@
 
 #pragma mark Framework
 - (void)refreshAnnotation:(TiMapAnnotationProxy *)proxy readd:(BOOL)yn;
-- (void)fireClickEvent:(MKAnnotationView *)pinview source:(NSString *)source;
+- (void)fireClickEvent:(MKAnnotationView *)pinview source:(NSString *)source deselected:(BOOL)deselected;
 
 @end

--- a/ios/Classes/TiMapView.m
+++ b/ios/Classes/TiMapView.m
@@ -1074,7 +1074,7 @@
         [self findCalloutView:ann];
       });
     }
-    [self fireClickEvent:view source:isSelected ? @"pin" : [ann lastHitName]];
+    [self fireClickEvent:view source:isSelected ? @"pin" : [ann lastHitName] deselected:NO];
   }
 }
 
@@ -1102,7 +1102,8 @@
       RELEASE_TO_NIL(ann);
     }
 
-    [self fireClickEvent:view source:isSelected ? @"pin" : @"map"];
+    // TODO: Fire a deselected event for the annotation?
+    [self fireClickEvent:view source:isSelected ? @"pin" : @"map" deselected:YES];
   }
 }
 
@@ -1116,7 +1117,7 @@
     } else if (aview.rightCalloutAccessoryView == control) {
       clickSource = @"rightButton";
     }
-    [self fireClickEvent:pinview source:clickSource];
+    [self fireClickEvent:pinview source:clickSource deselected:NO];
   }
 }
 
@@ -1342,7 +1343,7 @@
 
 - (void)handleCalloutTap:(UIGestureRecognizer *)sender
 {
-  [self fireClickEvent:selectedAnnotation source:@"infoWindow"];
+  [self fireClickEvent:selectedAnnotation source:@"infoWindow" deselected:NO];
 }
 
 - (void)handleLongPressOnMap:(UIGestureRecognizer *)sender
@@ -1433,7 +1434,7 @@
   [self.proxy fireEvent:event withObject:object];
 }
 
-- (void)fireClickEvent:(MKAnnotationView *)pinview source:(NSString *)source
+- (void)fireClickEvent:(MKAnnotationView *)pinview source:(NSString *)source deselected:(BOOL)deselected
 {
   if (ignoreClicks) {
     return;
@@ -1456,7 +1457,7 @@
 
   NSDictionary *event = [NSDictionary dictionaryWithObjectsAndKeys:
                                           clicksource, @"clicksource", viewProxy, @"annotation", mapProxy, @"map",
-                                      title, @"title", NUMINTEGER(indexNumber), @"index", nil];
+                                      title, @"title", NUMINTEGER(indexNumber), @"index", NUMBOOL(deselected), @"deselected", nil];
 
   [self doClickEvent:viewProxy mapProxy:mapProxy event:event];
 }

--- a/ios/manifest
+++ b/ios/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 3.2.0
+version: 3.3.0
 apiversion: 2
 architectures: armv7 arm64 i386 x86_64
 description: External version of Map module

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@titanium/ti.map",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titanium/ti.map",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "description": "Provides Map UI elements for Titanium applications",
   "scripts": {
     "lint": "npm run lint:docs",


### PR DESCRIPTION
**JIRA**: https://jira.appcelerator.org/browse/MOD-2545

**Description**:
Since the click event will fire twice when you click a different annotation I've added a parameter to see if the source was deselected or not. Same for clicking on the map instead of a second annotation.

```
var Map = require('ti.map');

var win = Ti.UI.createWindow({
	height: Ti.UI.FILL,
	width: Ti.UI.FILL
});
var map_view = Map.createView();


var south_korea = Map.createAnnotation({
	latitude: '36.792452',
	longitude: '127.995333',
	title: 'South Korea',
	pincolor: Map.ANNOTATION_BLUE
});

var north_korea = Map.createAnnotation({
	latitude: '39.763824',
	longitude: '126.856541',
	title: 'North Korea',
	pincolor: Map.ANNOTATION_RED
});

map_view.addAnnotation(south_korea);
map_view.addAnnotation(north_korea);

map_view.region = {
	latitude: '38.286344',
	longitude: '127.111459',
	zoom: 6
};

map_view.addEventListener('click', function(e) {
	Ti.API.info('Click ', e.title, ' clicksource: ', e.clicksource, ' type: ', e.type, " deselected: ", e.deselected);
});

win.add(map_view);

win.open();
```

* click first annoation
* click second annotation
* click map

output:
```
[INFO]  Click  North Korea  clicksource:  pin  type:  click  deselected:  false

[INFO]  Click  North Korea  clicksource:  pin  type:  click  deselected:  true
[INFO]  Click  South Korea  clicksource:  pin  type:  click  deselected:  false

[INFO]  Click  South Korea  clicksource:  null  type:  click  deselected:  true
```

iOS parity welcome!

[Testversion](http://migaweb.de/ti.map-android-4.5.0.zip)