### PR TITLE
Android: Add jointTypes

### DIFF
--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 5.0.3
+version: 5.1.0
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: External version of Map module using native Google Maps library

--- a/android/src/ti/map/MapModule.java
+++ b/android/src/ti/map/MapModule.java
@@ -131,6 +131,12 @@ public class MapModule extends KrollModule
 	public static final int POLYLINE_PATTERN_DASHED = 0;
 	@Kroll.constant
 	public static final int POLYLINE_PATTERN_DOTTED = 1;
+	@Kroll.constant
+	public static final int POLYLINE_JOINT_DEFAULT = 0;
+	@Kroll.constant
+	public static final int POLYLINE_JOINT_BEVEL = 1;
+	@Kroll.constant
+	public static final int POLYLINE_JOINT_ROUND = 2;
 
 	public MapModule()
 	{

--- a/android/src/ti/map/PolylineProxy.java
+++ b/android/src/ti/map/PolylineProxy.java
@@ -49,10 +49,12 @@ public class PolylineProxy extends KrollProxy implements IShape
 	private static final int MSG_SET_ZINDEX = MSG_FIRST_ID + 503;
 	private static final int MSG_SET_TOUCH_ENABLED = MSG_FIRST_ID + 504;
 	private static final int MSG_SET_STROKE_PATTERN = MSG_FIRST_ID + 505;
+	private static final int MSG_SET_STROKE_JOINT = MSG_FIRST_ID + 506;
 
 	public static final String PROPERTY_STROKE_COLOR2 = "color";
 	public static final String PROPERTY_STROKE_WIDTH2 = "width";
 	public static final String PROPERTY_STROKE_PATTERN2 = "pattern";
+	public static final String PROPERTY_JOINT_TYPE = "jointType";
 
 	public static final String PROPERTY_ZINDEX = "zIndex";
 
@@ -68,6 +70,7 @@ public class PolylineProxy extends KrollProxy implements IShape
 	{
 		super();
 		clickable = true;
+		defaultValues.put(PROPERTY_JOINT_TYPE, MapModule.POLYLINE_JOINT_DEFAULT);
 	}
 
 	@Override
@@ -98,6 +101,13 @@ public class PolylineProxy extends KrollProxy implements IShape
 				result = (AsyncResult) msg.obj;
 				int type = (Integer) result.getArg();
 				polyline.setPattern(processPatternDefinition(type));
+				result.setResult(null);
+				return true;
+			}
+			case MSG_SET_STROKE_JOINT: {
+				result = (AsyncResult) msg.obj;
+				int type = (Integer) result.getArg();
+				polyline.setJointType(type);
 				result.setResult(null);
 				return true;
 			}
@@ -165,6 +175,10 @@ public class PolylineProxy extends KrollProxy implements IShape
 				options.pattern(
 					processPatternDefinition(TiConvert.toInt(getProperty(PolylineProxy.PROPERTY_STROKE_PATTERN2))));
 			}
+		}
+
+		if (hasProperty(PolylineProxy.PROPERTY_JOINT_TYPE)) {
+			options.jointType(TiConvert.toInt(getProperty(PolylineProxy.PROPERTY_JOINT_TYPE), 0));
 		}
 	}
 

--- a/apidoc/Map.yml
+++ b/apidoc/Map.yml
@@ -275,19 +275,19 @@ properties:
     type: Number
     permission: read-only
     platforms: [android]
-    
+
   - name: REASON_DEVELOPER_ANIMATION
     summary: Used in the [regionwillchange](Modules.Map.View.regionwillchange) event. The camera moved in response to a request from the application.
     type: Number
     permission: read-only
     platforms: [android]
-    
+
   - name: REASON_GESTURE
     summary: Used in the [regionwillchange](Modules.Map.View.regionwillchange) event. The camera moved in response to the user gestures on the map.
     type: Number
     permission: read-only
     platforms: [android]
-    
+
   - name: SUCCESS
     summary: Code returned from <Modules.Map.isGooglePlayServicesAvailable>. Google Play services is available, and the connection is successful.
     type: Number
@@ -334,6 +334,30 @@ properties:
     since: "3.2.0"
     exclude-platforms: [android]
 
+  - name: POLYLINE_JOINT_BEVEL
+    summary: |
+        Flat bevel on the outside of the joint.
+    type: Number
+    permission: read-only
+    platforms: [android]
+    since: "5.1.0"
+
+  - name: POLYLINE_JOINT_DEFAULT
+    summary: |
+        Default: Mitered joint, with fixed pointed extrusion equal to half the stroke width on the outside of the joint.
+    type: Number
+    permission: read-only
+    platforms: [android]
+    since: "5.1.0"
+
+  - name: POLYLINE_JOINT_ROUND
+    summary: |
+        Rounded on the outside of the joint by an arc of radius equal to half the stroke width, centered at the vertex.
+    type: Number
+    permission: read-only
+    platforms: [android]
+    since: "5.1.0"
+
   - name: POLYLINE_PATTERN_DASHED
     summary: |
         Polyline type constant used to display a dashed polyline via <Modules.Map.Polyline.pattern> property.
@@ -351,7 +375,7 @@ properties:
   - name: FEATURE_VISIBILITY_ADAPTIVE
     summary: Constant indicating that title text adapts to the current map state.
     description: |
-        For markers in the normal state, title text is displayed and subtitle text is hidden. When a marker 
+        For markers in the normal state, title text is displayed and subtitle text is hidden. When a marker
         is selected, the title and subtitle text are hidden when the marker requires a callout.
     type: Number
     permission: read-only
@@ -389,8 +413,8 @@ properties:
     summary: Constant indicating that the item's display priority is high.
     description: |
         An annotation view with this priority is removed from the map when its bounds
-        collide with the bounds of another view with a higher priority. If the priorities 
-        of the two views are equal, the view furthest from the center of the map's visible 
+        collide with the bounds of another view with a higher priority. If the priorities
+        of the two views are equal, the view furthest from the center of the map's visible
         region is hidden first.
     type: Number
     permission: read-only
@@ -402,8 +426,8 @@ properties:
     summary: Constant indicating that the item's display priority is low.
     description: |
         An annotation view with this priority is removed from the map when its bounds
-        collide with the bounds of another view with a higher priority. If the priorities 
-        of the two views are equal, the view furthest from the center of the map's visible 
+        collide with the bounds of another view with a higher priority. If the priorities
+        of the two views are equal, the view furthest from the center of the map's visible
         region is hidden first.
     type: Number
     permission: read-only
@@ -413,7 +437,7 @@ properties:
 
   - name: ANNOTATION_VIEW_COLLISION_MODE_RECTANGLE
     summary: |
-        Constant indicating that the full collision frame rectangle should be used for 
+        Constant indicating that the full collision frame rectangle should be used for
         detecting collisions.
     type: Number
     permission: read-only
@@ -423,7 +447,7 @@ properties:
 
   - name: ANNOTATION_VIEW_COLLISION_MODE_CIRCLE
     summary: |
-        Constant indicating that a circle inscribed in the collision frame rectangle should 
+        Constant indicating that a circle inscribed in the collision frame rectangle should
         be used to determine collisions.
     type: Number
     permission: read-only
@@ -564,7 +588,7 @@ examples:
     example: |
         This is a map-example which creates marker annotation and clustering of annotations.
 
-        The `clusterIdentifier` property and the `clusterstart` event are required in order to enable 
+        The `clusterIdentifier` property and the `clusterstart` event are required in order to enable
         clustering. You can control the clustering by defining the `collisionMode` property and
         setting special cluster annotations using the `setClusterAnnotation` method on your map
         view instance.

--- a/apidoc/Polyline.yml
+++ b/apidoc/Polyline.yml
@@ -10,6 +10,17 @@ extends: Titanium.Proxy
 since: { android: "4.1.0", iphone: "4.1.0", ipad: "4.1.0", macos: "9.2.0" }
 platforms: [android, iphone, ipad, macos]
 properties:
+  - name: jointType
+    summary: Defines the shape of corner points.
+    description: |
+        Defines the shape of corner points. Can be one of the following shapes: <Modules.Map.POLYLINE_JOINT_DEFAULT>,
+        <Modules.Map.POLYLINE_JOINT_ROUND> or <Modules.Map.POLYLINE_JOINT_BEVEL>
+    availability: creation
+    type: Number
+    platforms: [android]
+    default: Modules.Map.POLYLINE_JOINT_DEFAULT
+    since: "5.1.0"
+
   - name: points
     summary: Array of map points making up the polyline. Can also be an array of longitude (index 0), latitude (index 1) touples.
     availability: creation
@@ -28,7 +39,7 @@ properties:
     summary: Line width in pixels to use when drawing the polyline.
     type: Number
     default: 10
-    
+
   - name: touchEnabled
     summary: Determines whether view should receive touch events.
     type: Boolean
@@ -47,11 +58,11 @@ properties:
   - name: pattern
     summary: Pattern used to draw the polylines.
     description: |
-        As per default polylines are drawn with a solid line. You can specify to 
-        draw them with a dashed line using <Modules.Map.POLYLINE_PATTERN_DASHED> 
+        As per default polylines are drawn with a solid line. You can specify to
+        draw them with a dashed line using <Modules.Map.POLYLINE_PATTERN_DASHED>
         or with a dotted line using <Modules.Map.POLYLINE_PATTERN_DOTTED>.
 
-        You can also specify the dimensions to use when you create a dashed or 
+        You can also specify the dimensions to use when you create a dashed or
         dotted polyline.
 
         For a dashed polyline, you can do something like this:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@titanium-sdk/ti.map",
-  "version": "6.0.2",
+  "version": "6.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titanium-sdk/ti.map",
-  "version": "6.0.2",
+  "version": "6.1.0",
   "description": "Provides Map UI elements for Titanium applications",
   "scripts": {
     "commit": "git-cz",

--- a/test/unit/specs/polyline.spec.js
+++ b/test/unit/specs/polyline.spec.js
@@ -1,4 +1,6 @@
 const Map = require('ti.map');
+
+const ANDROID = (Ti.Platform.osname === 'android');
 const IOS = (Ti.Platform.osname === 'iphone' || Ti.Platform.osname === 'ipad');
 
 describe('ti.map', () => {
@@ -63,4 +65,11 @@ describe('ti.map.Polyline', () => {
 		expect(polyline.zIndex).toEqual(10);
 	});
 
+	if (ANDROID) {
+		describe('.jointType', () => {
+			it('defaults to POLYLINE_JOINT_DEFAULT', () => {
+				expect(polyline.jointType).toEqual(Map.POLYLINE_JOINT_DEFAULT);
+			});
+		});
+	}
 });


### PR DESCRIPTION
```JS
var Map = require('ti.map');

    var win = Ti.UI.createWindow({
        height: Ti.UI.FILL,
        width: Ti.UI.FILL
    });
    var map_view = Map.createView();

    map_view.region = {
        latitude: '37.3895100',
        longitude: '-122.0502150',
        zoom: 10
    };


    win.add(map_view);

    var btn = Ti.UI.createButton({
        title: "add route",
        bottom: 10
    })
    win.add(btn);

    var t = [Map.POLYLINE_JOINT_DEFAULT, Map.POLYLINE_JOINT_ROUND, Map.POLYLINE_JOINT_BEVEL];
    var ti = 0;
    var pl = null;

    btn.addEventListener("click", function() {

        if (pl) map_view.removePolyline(pl);
        pl = Map.createPolyline({
            points: [
                [-122.0201890, 37.3316920],
                [-122.0741890, 37.2223450],
                [-122.0602150, 37.3895100]
            ],
            strokeColor: '#ff00aa',
            strokeWidth: 15,
            jointType: t[ti]
        });
        map_view.addPolyline(pl);
        ti++;
        if (ti > 2) {
            ti = 0;
        }
    })
    win.open();
```

Add the possibility to change the jointTypes (the corners). Run the demo code and click the button to cycle through the different modes (round, bevel, default)