### PR TITLE
Android: Null check in TiMarker

### DIFF
--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 4.5.0
+version: 4.5.1
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86
 description: External version of Map module to support new Google Map v2 sdk

--- a/android/src/ti/map/AnnotationProxy.java
+++ b/android/src/ti/map/AnnotationProxy.java
@@ -6,8 +6,14 @@
  */
 package ti.map;
 
+import android.graphics.Bitmap;
+import android.os.Message;
+import android.view.View;
+import com.google.android.gms.maps.model.BitmapDescriptorFactory;
+import com.google.android.gms.maps.model.LatLng;
+import com.google.android.gms.maps.model.Marker;
+import com.google.android.gms.maps.model.MarkerOptions;
 import java.util.HashMap;
-
 import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.KrollProxy;
 import org.appcelerator.kroll.annotations.Kroll;
@@ -22,15 +28,6 @@ import org.appcelerator.titanium.TiPoint;
 import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.util.TiConvert;
 import org.appcelerator.titanium.view.TiDrawableReference;
-
-import android.graphics.Bitmap;
-import android.os.Message;
-import android.view.View;
-
-import com.google.android.gms.maps.model.BitmapDescriptorFactory;
-import com.google.android.gms.maps.model.LatLng;
-import com.google.android.gms.maps.model.Marker;
-import com.google.android.gms.maps.model.MarkerOptions;
 
 @Kroll.proxy(creatableInModule = MapModule.class,
 			 propertyAccessors = { TiC.PROPERTY_SUBTITLE, TiC.PROPERTY_SUBTITLEID, TiC.PROPERTY_TITLE,
@@ -156,14 +153,20 @@ public class AnnotationProxy extends KrollProxy
 
 			case MSG_SET_HIDDEN: {
 				result = (AsyncResult) msg.obj;
-				marker.getMarker().setVisible(!(Boolean) result.getArg());
+				Marker m = marker.getMarker();
+				if (m != null) {
+					m.setVisible(!(Boolean) result.getArg());
+				}
 				result.setResult(null);
 				return true;
 			}
 
 			case MSG_SET_DRAGGABLE: {
 				result = (AsyncResult) msg.obj;
-				marker.getMarker().setDraggable((Boolean) result.getArg());
+				Marker m = marker.getMarker();
+				if (m != null) {
+					m.setDraggable((Boolean) result.getArg());
+				}
 				result.setResult(null);
 				return true;
 			}
@@ -181,7 +184,10 @@ public class AnnotationProxy extends KrollProxy
 
 	public void setPosition(double latitude, double longitude)
 	{
-		marker.getMarker().setPosition(new LatLng(latitude, longitude));
+		Marker m = marker.getMarker();
+		if (m != null) {
+			m.setPosition(new LatLng(latitude, longitude));
+		}
 	}
 
 	public void processOptions()

--- a/android/src/ti/map/TiClusterRenderer.java
+++ b/android/src/ti/map/TiClusterRenderer.java
@@ -1,22 +1,22 @@
 package ti.map;
 
-import com.google.maps.android.clustering.view.DefaultClusterRenderer;
-import com.google.android.gms.maps.GoogleMap;
 import android.content.Context;
-import com.google.maps.android.clustering.ClusterManager;
-import com.google.android.gms.maps.model.Marker;
-import org.appcelerator.titanium.view.TiDrawableReference;
 import android.graphics.Bitmap;
-import com.google.android.gms.maps.model.MarkerOptions;
-import org.appcelerator.titanium.TiApplication;
-import com.google.android.gms.maps.model.BitmapDescriptorFactory;
 import android.view.View;
+import com.google.android.gms.maps.GoogleMap;
+import com.google.android.gms.maps.model.BitmapDescriptorFactory;
+import com.google.android.gms.maps.model.Marker;
+import com.google.android.gms.maps.model.MarkerOptions;
+import com.google.maps.android.clustering.ClusterManager;
+import com.google.maps.android.clustering.view.DefaultClusterRenderer;
+import java.util.HashMap;
+import org.appcelerator.kroll.common.Log;
+import org.appcelerator.titanium.TiApplication;
+import org.appcelerator.titanium.TiBlob;
+import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.TiDimension;
 import org.appcelerator.titanium.TiPoint;
-import java.util.HashMap;
-import org.appcelerator.titanium.TiC;
-import org.appcelerator.kroll.common.Log;
-import org.appcelerator.titanium.TiBlob;
+import org.appcelerator.titanium.view.TiDrawableReference;
 
 public class TiClusterRenderer extends DefaultClusterRenderer<TiMarker>
 {
@@ -36,17 +36,18 @@ public class TiClusterRenderer extends DefaultClusterRenderer<TiMarker>
 	{
 
 		AnnotationProxy anno = clusterItem.getProxy();
+		if (anno != null) {
+			if (anno.hasProperty(TiC.PROPERTY_IMAGE)) {
+				handleImage(anno, markerOptions, anno.getProperty(TiC.PROPERTY_IMAGE));
+			}
 
-		if (anno.hasProperty(TiC.PROPERTY_IMAGE)) {
-			handleImage(anno, markerOptions, anno.getProperty(TiC.PROPERTY_IMAGE));
-		}
-
-		if (anno.hasProperty(MapModule.PROPERTY_CENTER_OFFSET)) {
-			HashMap centerOffsetProperty = (HashMap) anno.getProperty(MapModule.PROPERTY_CENTER_OFFSET);
-			TiPoint centerOffset = new TiPoint(centerOffsetProperty, 0.0, 0.0);
-			float offsetX = 0.5f - ((float) centerOffset.getX().getValue() / (float) iconImageWidth);
-			float offsetY = 0.5f - ((float) centerOffset.getY().getValue() / (float) iconImageHeight);
-			markerOptions.anchor(offsetX, offsetY);
+			if (anno.hasProperty(MapModule.PROPERTY_CENTER_OFFSET)) {
+				HashMap centerOffsetProperty = (HashMap) anno.getProperty(MapModule.PROPERTY_CENTER_OFFSET);
+				TiPoint centerOffset = new TiPoint(centerOffsetProperty, 0.0, 0.0);
+				float offsetX = 0.5f - ((float) centerOffset.getX().getValue() / (float) iconImageWidth);
+				float offsetY = 0.5f - ((float) centerOffset.getY().getValue() / (float) iconImageHeight);
+				markerOptions.anchor(offsetX, offsetY);
+			}
 		}
 	}
 

--- a/android/src/ti/map/TiMarker.java
+++ b/android/src/ti/map/TiMarker.java
@@ -53,9 +53,8 @@ public class TiMarker implements ClusterItem
 	{
 		if (proxy != null) {
 			return proxy.getMarkerOptions().getPosition();
-		} else {
-			return null;
 		}
+		return null;
 	}
 
 	@Override
@@ -63,9 +62,8 @@ public class TiMarker implements ClusterItem
 	{
 		if (proxy != null) {
 			return proxy.getTitle();
-		} else {
-			return "";
 		}
+		return null;
 	}
 
 	@Override
@@ -73,8 +71,7 @@ public class TiMarker implements ClusterItem
 	{
 		if (proxy != null) {
 			return proxy.getSubtitle();
-		} else {
-			return "";
 		}
+		return null;
 	}
 }

--- a/android/src/ti/map/TiMarker.java
+++ b/android/src/ti/map/TiMarker.java
@@ -51,18 +51,30 @@ public class TiMarker implements ClusterItem
 	@Override
 	public LatLng getPosition()
 	{
-		return proxy.getMarkerOptions().getPosition();
+		if (proxy != null) {
+			return proxy.getMarkerOptions().getPosition();
+		} else {
+			return null;
+		}
 	}
 
 	@Override
 	public String getTitle()
 	{
-		return proxy.getTitle();
+		if (proxy != null) {
+			return proxy.getTitle();
+		} else {
+			return "";
+		}
 	}
 
 	@Override
 	public String getSnippet()
 	{
-		return proxy.getSubtitle();
+		if (proxy != null) {
+			return proxy.getSubtitle();
+		} else {
+			return "";
+		}
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3699,10 +3699,13 @@
       }
     },
     "eslint-utils": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
-      "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
-      "dev": true
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
+      "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.0.0"
+      }
     },
     "eslint-visitor-keys": {
       "version": "1.0.0",
@@ -6451,9 +6454,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
     "lodash._reinterpolate": {
@@ -6908,9 +6911,9 @@
       }
     },
     "mixin-deep": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
       "dev": true,
       "requires": {
         "for-in": "^1.0.2",
@@ -8121,9 +8124,9 @@
       "dev": true
     },
     "set-value": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
       "dev": true,
       "requires": {
         "extend-shallow": "^2.0.1",
@@ -9130,38 +9133,15 @@
       "dev": true
     },
     "union-value": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
       "dev": true,
       "requires": {
         "arr-union": "^3.1.0",
         "get-value": "^2.0.6",
         "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        },
-        "set-value": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
-          }
-        }
+        "set-value": "^2.0.1"
       }
     },
     "universal-user-agent": {


### PR DESCRIPTION
Had this error message during running my app:
```
INFO]  Choreographer: Skipped 74 frames!  The application may be doing too much work on its main thread.
[ERROR] TiExceptionHandler: (main) [66,251578] Attempt to invoke virtual method 'java.lang.String ti.map.AnnotationProxy.getTitle()' on a null object reference
[ERROR] TiExceptionHandler:
[ERROR] TiExceptionHandler:     ti.map.TiMarker.getTitle(TiMarker.java:60)
[ERROR] TiExceptionHandler:     com.google.maps.android.clustering.view.DefaultClusterRenderer$CreateMarkerTask.perform(DefaultClusterRenderer.java:835)
[ERROR] TiExceptionHandler:     com.google.maps.android.clustering.view.DefaultClusterRenderer$CreateMarkerTask.access$2100(DefaultClusterRenderer.java:805)
[ERROR] TiExceptionHandler:     com.google.maps.android.clustering.view.DefaultClusterRenderer$MarkerModifier.performNextTask(DefaultClusterRenderer.java:644)
[ERROR] TiExceptionHandler:     com.google.maps.android.clustering.view.DefaultClusterRenderer$MarkerModifier.handleMessage(DefaultClusterRenderer.java:615)
[ERROR] TiExceptionHandler:     android.os.Handler.dispatchMessage(Handler.java:102)
[ERROR] TiExceptionHandler:     android.os.Looper.loop(Looper.java:173)
[ERROR] TiExceptionHandler:     android.app.ActivityThread.main(ActivityThread.java:6459)
[ERROR] TiExceptionHandler:     java.lang.reflect.Method.invoke(Native Method)
[ERROR] TiExceptionHandler:     com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:938)
[ERROR] TiExceptionHandler:     com.android.internal.os.ZygoteInit.main(ZygoteInit.java:828)
[INFO]  art: Starting a blocking GC HeapTrim
```
Not sure how it appeared (compiling the app again and it worked fine) but adding a null check around those return statements shouldn't harm.

Trying to see why that error occurred and will add a JIRA ticket