### PR TITLE
Android: Update Android Example app 

### DIFF
--- a/android/example/app.js
+++ b/android/example/app.js
@@ -1,15 +1,3 @@
-
-/**
- * If the table view rows are too small on Android, add the following to your tiapp.xml
- *
-<android xmlns:android="http://schemas.android.com/apk/res/android">
-    <manifest>
-        <supports-screens android:anyDensity="false"/>
-    </manifest>
-</android>
- *
- */
-
 var IOS = (Ti.Platform.osname === 'iphone' || Ti.Platform.osname === 'ipad');
 var ANDROID = (Ti.Platform.osname === 'android');
 var UI = require('ui');

--- a/android/example/ui.js
+++ b/android/example/ui.js
@@ -3,7 +3,7 @@ var nav;
 
 function init(rows, onClick) {
     var win = Ti.UI.createWindow({
-        backgroundColor: '#FFF',
+        backgroundColor: 'gray',
         title: 'Ti.Map',
         translucent: false
     });
@@ -13,7 +13,9 @@ function init(rows, onClick) {
     for (var row in rows) {
         transformedRows.push({
             title: rows[row].title,
-            hasChild: true
+            font: {
+            fontSize: 25
+           }
         });
     }
 

--- a/android/example/ui.js
+++ b/android/example/ui.js
@@ -14,7 +14,7 @@ function init(rows, onClick) {
         transformedRows.push({
             title: rows[row].title,
             font: {
-            fontSize: 25
+                fontSize: 25
            }
         });
     }


### PR DESCRIPTION
This PR removes the suggestion mentioned in the `app.js` as it causes the maps on Devices and simulators to go black. A change to the app ui on Android was made so the app text can be visible when using the example app.

Jira ticket: https://jira.appcelerator.org/browse/MOD-2549

**Note:** Issue of multi maps crashing the app can be tracked here: https://jira.appcelerator.org/browse/MOD-2548