### PR TITLE
fix(ios): check for null proxy in onMyLocationChange to prevent app crash when location received after proxy is closed

### DIFF
--- a/android/src/ti/map/TiUIMapView.java
+++ b/android/src/ti/map/TiUIMapView.java
@@ -1257,10 +1257,12 @@ public class TiUIMapView extends TiUIFragment
 	@Override
 	public void onMyLocationChange(Location arg0)
 	{
-		KrollDict d = new KrollDict();
-		d.put(TiC.PROPERTY_LATITUDE, arg0.getLatitude());
-		d.put(TiC.PROPERTY_LONGITUDE, arg0.getLongitude());
-		proxy.fireEvent(MapModule.EVENT_USER_LOCATION, d);
+		if (proxy != null) {
+			KrollDict d = new KrollDict();
+			d.put(TiC.PROPERTY_LATITUDE, arg0.getLatitude());
+			d.put(TiC.PROPERTY_LONGITUDE, arg0.getLongitude());
+			proxy.fireEvent(MapModule.EVENT_USER_LOCATION, d);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
This fix checks for a null parent proxy object in onMyLocationChange to prevent app crash when location received after proxy is closed.

Encountered this bug when embedding a map in a screen. On screen close, the app crashed with the below exception. The proxy object should be checked for null before trying to post an event to it to avoid these boundary conditions.

After fixing this and rebuilding the ti.map module, this error couldn't be reproduced. It was easy to reproduce prior to this.

Stack trace:

[DEBUG] AndroidRuntime: Shutting down VM
[ERROR] TiExceptionHandler: (main) [5182986,5251852] Attempt to invoke virtual method 'boolean org.appcelerator.titanium.proxy.TiViewProxy.fireEvent(java.lang.String, java.lang.Object)' on a null object reference
[ERROR] TiExceptionHandler:
[ERROR] TiExceptionHandler:     ti.map.TiUIMapView.onMyLocationChange(TiUIMapView.java:1263)
[ERROR] TiExceptionHandler:     com.google.android.gms.maps.zzh.zza(Unknown Source:2)
[ERROR] TiExceptionHandler:     com.google.android.gms.maps.internal.zzay.dispatchTransaction(Unknown Source:5)
[ERROR] TiExceptionHandler:     com.google.android.gms.internal.maps.zzb.onTransact(Unknown Source:12)
[ERROR] TiExceptionHandler:     android.os.Binder.transact(Binder.java:1043)
[ERROR] TiExceptionHandler:     dp.aZ(:com.google.android.gms.dynamite_mapsdynamite@211515100@21.15.15 (150700-0):2)
[ERROR] TiExceptionHandler:     com.google.maps.api.android.lib6.impl.dg.f(:com.google.android.gms.dynamite_mapsdynamite@211515100@21.15.15 (150700-0):2)
[ERROR] TiExceptionHandler:     com.google.maps.api.android.lib6.impl.dg.e(:com.google.android.gms.dynamite_mapsdynamite@211515100@21.15.15 (150700-0):0)
[ERROR] TiExceptionHandler:     com.google.maps.api.android.lib6.impl.cp.run(:com.google.android.gms.dynamite_mapsdynamite@211515100@21.15.15 (150700-0):1)
[ERROR] TiExceptionHandler:     android.os.Handler.handleCallback(Handler.java:938)
[ERROR] TiExceptionHandler:     android.os.Handler.dispatchMessage(Handler.java:99)
[ERROR] TiExceptionHandler:     android.os.Looper.loop(Looper.java:223)
[ERROR] TiExceptionHandler:     android.app.ActivityThread.main(ActivityThread.java:7656)
[ERROR] TiExceptionHandler:     java.lang.reflect.Method.invoke(Native Method)
[ERROR] TiExceptionHandler:     com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592)
[ERROR] TiExceptionHandler:     com.android.internal.os.ZygoteInit.main(ZygoteInit.java:947)
[INFO]  I/om.viryanet.vn: Thread[4,tid=8868,WaitingInMainSignalCatcherLoop,Thread*=0xde48a810,peer=0x13245bd8,"Signal Catcher"]: reacting to signal 3
[INFO]  I/om.viryanet.vn:
[INFO]  I/om.viryanet.vn: Wrote stack traces to tombstoned
