### PR TITLE
added showPin option to snapshotter

### DIFF
--- a/ios/Classes/TiMapSnapshotterProxy.m
+++ b/ios/Classes/TiMapSnapshotterProxy.m
@@ -12,6 +12,10 @@
 
 @implementation TiMapSnapshotterProxy
 
+CLLocationDegrees latitudeCoord;
+CLLocationDegrees longitudeCoord;
+bool showPin = NO;
+
 - (NSString *)apiName
 {
   return @"Ti.Map.Snapshotter";
@@ -27,10 +31,14 @@
 {
   CLLocationDegrees latitudeDelta = [TiUtils floatValue:@"latitudeDelta" properties:dict];
   CLLocationDegrees longitudeDelta = [TiUtils floatValue:@"longitudeDelta" properties:dict];
+    
 
   CLLocationDegrees latitude = [TiUtils floatValue:@"latitude" properties:dict];
   CLLocationDegrees longitude = [TiUtils floatValue:@"longitude" properties:dict];
 
+    latitudeCoord = latitude;
+    longitudeCoord = longitude;
+    
   return MKCoordinateRegionMake(CLLocationCoordinate2DMake(latitude, longitude), MKCoordinateSpanMake(latitudeDelta, longitudeDelta));
 }
 
@@ -56,6 +64,13 @@
   ENSURE_TYPE(value, NSNumber);
   [[self options] setMapType:[TiUtils intValue:value]];
 }
+
+- (void)setShowPin:(id)value
+{
+  ENSURE_TYPE(value, NSNumber);
+  showPin = [TiUtils boolValue:value];
+}
+
 
 - (void)setShowsBuildings:(id)value
 {
@@ -91,8 +106,41 @@
       [self _fireEventToListener:@"blob" withObject:[TiUtils stringValue:error] listener:ErrorCallback thisObject:nil];
       return;
     }
+      TiBlob *blob;
+      
+      if (showPin == YES){
+        CGRect finalImageRect = CGRectMake(0, 0, snapshot.image.size.width, snapshot.image.size.height);
 
-    TiBlob *blob = [[TiBlob alloc] initWithImage:snapshot.image];
+        MKAnnotationView *pin = [[MKPinAnnotationView alloc] initWithAnnotation:nil reuseIdentifier:@""];
+        UIImage *pinImage = pin.image;
+
+        // ok, let's start to create our final image
+        UIGraphicsBeginImageContextWithOptions(snapshot.image.size, YES, snapshot.image.scale);
+
+        // first, draw the image from the snapshotter
+        [snapshot.image drawAtPoint:CGPointMake(0, 0)];
+
+        CGPoint point = [snapshot pointForCoordinate:CLLocationCoordinate2DMake(latitudeCoord, longitudeCoord)];
+        
+        if (CGRectContainsPoint(finalImageRect, point)) // this is too conservative, but you get the idea
+        {
+            CGPoint pinCenterOffset = pin.centerOffset;
+            point.x -= pin.bounds.size.width / 2.0;
+            point.y -= pin.bounds.size.height / 2.0;
+            point.x += pinCenterOffset.x;
+            point.y += pinCenterOffset.y;
+
+            [pinImage drawAtPoint:point];
+        }
+        UIImage *finalImage = UIGraphicsGetImageFromCurrentImageContext();
+        UIGraphicsEndImageContext();
+          
+        blob = [[TiBlob alloc] initWithImage:finalImage];
+      }
+      else{
+        blob = [[TiBlob alloc] initWithImage:snapshot.image];
+      }
+      
     [blob setMimeType:@"image/png" type:TiBlobTypeImage];
 
     NSDictionary *event = [NSDictionary dictionaryWithObject:blob forKey:@"image"];


### PR DESCRIPTION
when snapshotting a location the option to display a pin (annotation) in the snapshot image was missing

option "showPin" (default is set to FALSE) will allow to display a pin




var Snapshotter = .Map.createSnapshotter({
		mapType: global.Map.NORMAL_TYPE,
		showPin:true,
		region: {
			latitude: location.latitude,
			longitude: location.longitude
		},
		size: {
			width: 300, 
			height: 200
		}
	});