### PR TITLE
fix(android): Marker click event

### DIFF
--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 5.3.3
+version: 5.3.4
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: External version of Map module using native Google Maps library

--- a/android/src/ti/map/TiUIMapView.java
+++ b/android/src/ti/map/TiUIMapView.java
@@ -231,6 +231,7 @@ public class TiUIMapView extends TiUIFragment
 		map.setOnMyLocationChangeListener(this);
 		collection.setInfoWindowAdapter(this);
 		collection.setOnInfoWindowClickListener(this);
+		collection.setOnMarkerClickListener(this);
 
 		mClusterManager.setOnClusterClickListener(this);
 		mClusterManager.setOnClusterItemClickListener(this);


### PR DESCRIPTION
Relates #495 
Marker click event for pin is not visible when using a normal marker (not a cluster):

```js
var win = Titanium.UI.createWindow({
	layout: "vertical"
});

let mapView = require('ti.map').createView({
	region: {
		latitude: 52.23,
		longitude: 13.401,
		latitudeDelta: 0.1,
		longitudeDelta: 0.1
	}
});
win.add(mapView);

let an1 = require("ti.map").createAnnotation({
	latitude: 52.23,
	longitude: 13.401,
	title: "Anno 1",
	subtitle: "Subtitle 1",
	pincolor: Map.ANNOTATION_RED
});

mapView.annotations = [an1];
mapView.addEventListener("click", function(e) {
	console.log(e.clicksource);
})
win.open();
```

current workaround:
add `clusterIdentifier:"test"`

[ti.map-android-5.3.4.zip](https://github.com/appcelerator-modules/ti.map/files/7487718/ti.map-android-5.3.4.zip)


