### PR TITLE
feat(android): mbtiles overlay

### DIFF
--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 5.5.0
+version: 5.6.0
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: External version of Map module using native Google Maps library

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 5.7.0
+version: 5.8.0
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: External version of Map module using native Google Maps library
@@ -15,5 +15,5 @@ name: map
 moduleid: ti.map
 guid: f0d8fd44-86d2-4730-b67d-bd454577aeee
 platform: android
-minsdk: 12.7.0
+minsdk: 13.0.0
 respackage: com.google.android.gms

--- a/android/src/ti/map/MapBoxOfflineTileProvider.java
+++ b/android/src/ti/map/MapBoxOfflineTileProvider.java
@@ -8,6 +8,7 @@ import com.google.android.gms.maps.model.Tile;
 import com.google.android.gms.maps.model.TileProvider;
 import java.io.Closeable;
 import java.io.File;
+import org.appcelerator.kroll.common.Log;
 
 public class MapBoxOfflineTileProvider implements TileProvider, Closeable
 {
@@ -38,9 +39,13 @@ public class MapBoxOfflineTileProvider implements TileProvider, Closeable
 	public MapBoxOfflineTileProvider(String pathToFile)
 	{
 		int flags = SQLiteDatabase.OPEN_READONLY | SQLiteDatabase.NO_LOCALIZED_COLLATORS;
-		this.mDatabase = SQLiteDatabase.openDatabase(pathToFile, null, flags);
-		this.calculateZoomConstraints();
-		this.calculateBounds();
+		try {
+			this.mDatabase = SQLiteDatabase.openDatabase(pathToFile, null, flags);
+			this.calculateZoomConstraints();
+			this.calculateBounds();
+		} catch (Error e) {
+			Log.e("TiUIMapView", "Error loading mbtiles file");
+		}
 	}
 
 	// ------------------------------------------------------------------------

--- a/android/src/ti/map/MapBoxOfflineTileProvider.java
+++ b/android/src/ti/map/MapBoxOfflineTileProvider.java
@@ -1,0 +1,220 @@
+package ti.map;
+
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+import com.google.android.gms.maps.model.LatLng;
+import com.google.android.gms.maps.model.LatLngBounds;
+import com.google.android.gms.maps.model.Tile;
+import com.google.android.gms.maps.model.TileProvider;
+import java.io.Closeable;
+import java.io.File;
+
+public class MapBoxOfflineTileProvider implements TileProvider, Closeable
+{
+
+	// ------------------------------------------------------------------------
+	// Instance Variables
+	// ------------------------------------------------------------------------
+
+	private int mMinimumZoom = Integer.MIN_VALUE;
+
+	private int mMaximumZoom = Integer.MAX_VALUE;
+
+	private LatLngBounds mBounds;
+
+	private SQLiteDatabase mDatabase;
+
+	private final Object mDatabaseLock = new Object();
+
+	// ------------------------------------------------------------------------
+	// Constructors
+	// ------------------------------------------------------------------------
+
+	public MapBoxOfflineTileProvider(File file)
+	{
+		this(file.getAbsolutePath());
+	}
+
+	public MapBoxOfflineTileProvider(String pathToFile)
+	{
+		int flags = SQLiteDatabase.OPEN_READONLY | SQLiteDatabase.NO_LOCALIZED_COLLATORS;
+		this.mDatabase = SQLiteDatabase.openDatabase(pathToFile, null, flags);
+		this.calculateZoomConstraints();
+		this.calculateBounds();
+	}
+
+	// ------------------------------------------------------------------------
+	// TileProvider Interface
+	// ------------------------------------------------------------------------
+
+	@Override
+	public Tile getTile(int x, int y, int z)
+	{
+		Tile tile = NO_TILE;
+		synchronized (mDatabaseLock) {
+			if (this.isZoomLevelAvailable(z) && this.isDatabaseAvailable()) {
+				String[] projection = { "tile_data" };
+				int row = ((int) (Math.pow(2, z) - y) - 1);
+				String predicate = "tile_row = ? AND tile_column = ? AND zoom_level = ?";
+				String[] values = { String.valueOf(row), String.valueOf(x), String.valueOf(z) };
+				Cursor c = this.mDatabase.query("tiles", projection, predicate, values, null, null, null);
+				if (c != null) {
+					c.moveToFirst();
+					if (!c.isAfterLast()) {
+						tile = new Tile(256, 256, c.getBlob(0));
+					}
+					c.close();
+				}
+			}
+		}
+		return tile;
+	}
+
+	// ------------------------------------------------------------------------
+	// Closeable Interface
+	// ------------------------------------------------------------------------
+
+	/**
+     * Closes the provider, cleaning up any background resources.
+     *
+     * <p>
+     * You must call {@link #close()} when you are finished using an instance of
+     * this provider. Failing to do so may leak resources, such as the backing
+     * SQLiteDatabase.
+     * </p>
+     */
+	@Override
+	public void close()
+	{
+		synchronized (mDatabaseLock) {
+			if (this.mDatabase != null) {
+				this.mDatabase.close();
+				this.mDatabase = null;
+			}
+		}
+	}
+
+	// ------------------------------------------------------------------------
+	// Public Methods
+	// ------------------------------------------------------------------------
+
+	public void swapDatabase(File newDatabaseFile)
+	{
+		synchronized (mDatabaseLock) {
+			mDatabase.close();
+			int flags = SQLiteDatabase.OPEN_READONLY | SQLiteDatabase.NO_LOCALIZED_COLLATORS;
+			this.mDatabase = SQLiteDatabase.openDatabase(newDatabaseFile.getAbsolutePath(), null, flags);
+		}
+	}
+	/**
+     * The minimum zoom level supported by this provider.
+     *
+     * @return the minimum zoom level supported or {@link Integer.MIN_VALUE} if
+     *         it could not be determined.
+     */
+	public int getMinimumZoom()
+	{
+		return this.mMinimumZoom;
+	}
+
+	/**
+     * The maximum zoom level supported by this provider.
+     *
+     * @return the maximum zoom level supported or {@link Integer.MAX_VALUE} if
+     *         it could not be determined.
+     */
+	public int getMaximumZoom()
+	{
+		return this.mMaximumZoom;
+	}
+
+	/**
+     * The geographic bounds available from this provider.
+     *
+     * @return the geographic bounds available or {@link null} if it could not
+     *         be determined.
+     */
+	public LatLngBounds getBounds()
+	{
+		return this.mBounds;
+	}
+
+	/**
+     * Determines if the requested zoom level is supported by this provider.
+     *
+     * @param zoom The requested zoom level.
+     * @return {@code true} if the requested zoom level is supported by this
+     *         provider.
+     */
+	public boolean isZoomLevelAvailable(int zoom)
+	{
+		return (zoom >= this.mMinimumZoom) && (zoom <= this.mMaximumZoom);
+	}
+
+	// ------------------------------------------------------------------------
+	// Private Methods
+	// ------------------------------------------------------------------------
+
+	private void calculateZoomConstraints()
+	{
+		if (this.isDatabaseAvailable()) {
+			String[] projection = new String[] { "value" };
+
+			String[] minArgs = new String[] { "minzoom" };
+
+			String[] maxArgs = new String[] { "maxzoom" };
+
+			Cursor c;
+
+			c = this.mDatabase.query("metadata", projection, "name = ?", minArgs, null, null, null);
+
+			c.moveToFirst();
+			if (!c.isAfterLast()) {
+				this.mMinimumZoom = c.getInt(0);
+			}
+			c.close();
+
+			c = this.mDatabase.query("metadata", projection, "name = ?", maxArgs, null, null, null);
+
+			c.moveToFirst();
+			if (!c.isAfterLast()) {
+				this.mMaximumZoom = c.getInt(0);
+			}
+			c.close();
+		}
+	}
+
+	private void calculateBounds()
+	{
+		if (this.isDatabaseAvailable()) {
+			String[] projection = new String[] { "value" };
+
+			String[] subArgs = new String[] { "bounds" };
+
+			Cursor c = this.mDatabase.query("metadata", projection, "name = ?", subArgs, null, null, null);
+
+			c.moveToFirst();
+			if (!c.isAfterLast()) {
+				String[] parts = c.getString(0).split(",\\s*");
+
+				double w = Double.parseDouble(parts[0]);
+				double s = Double.parseDouble(parts[1]);
+				double e = Double.parseDouble(parts[2]);
+				double n = Double.parseDouble(parts[3]);
+
+				LatLng ne = new LatLng(n, e);
+				LatLng sw = new LatLng(s, w);
+
+				this.mBounds = new LatLngBounds(sw, ne);
+			}
+			c.close();
+		}
+	}
+
+	private boolean isDatabaseAvailable()
+	{
+		synchronized (mDatabaseLock) {
+			return (this.mDatabase != null) && (this.mDatabase.isOpen());
+		}
+	}
+}

--- a/android/src/ti/map/MapModule.java
+++ b/android/src/ti/map/MapModule.java
@@ -79,6 +79,8 @@ public class MapModule extends KrollModule implements OnMapsSdkInitializedCallba
 	public static final String PROPERTY_PITCH = "pitch";
 
 	@Kroll.constant
+	public static final int TYPE_NONE = GoogleMap.MAP_TYPE_NONE;
+	@Kroll.constant
 	public static final int NORMAL_TYPE = GoogleMap.MAP_TYPE_NORMAL;
 	@Kroll.constant
 	public static final int TERRAIN_TYPE = GoogleMap.MAP_TYPE_TERRAIN;

--- a/android/src/ti/map/TiUIMapView.java
+++ b/android/src/ti/map/TiUIMapView.java
@@ -88,6 +88,8 @@ public class TiUIMapView extends TiUIFragment
 	private DefaultClusterRenderer clusterRender;
 	private MarkerManager mMarkerManager;
 	private MarkerManager.Collection collection;
+	private float minZoom = -1;
+	private float maxZoom = -1;
 
 	public TiUIMapView(final TiViewProxy proxy, Activity activity)
 	{
@@ -239,7 +241,12 @@ public class TiUIMapView extends TiUIFragment
 		markerCollection.setInfoWindowAdapter(this);
 		markerCollection.setOnInfoWindowClickListener(this);
 		markerCollection.setOnMarkerDragListener(this);
-
+		if (minZoom != -1) {
+			map.setMinZoomPreference(minZoom);
+		}
+		if (maxZoom != -1) {
+			map.setMaxZoomPreference(maxZoom);
+		}
 		((ViewProxy) proxy).clearPreloadObjects();
 	}
 
@@ -321,6 +328,12 @@ public class TiUIMapView extends TiUIFragment
 		if (d.containsKey(MapModule.PROPERTY_MIN_CLUSTER_SIZE)) {
 			if (clusterRender != null)
 				clusterRender.setMinClusterSize(d.getInt(MapModule.PROPERTY_MIN_CLUSTER_SIZE));
+		}
+		if (d.containsKey("maxZoomLevel")) {
+			maxZoom = Float.parseFloat(d.getString("maxZoomLevel"));
+		}
+		if (d.containsKey("minZoomLevel")) {
+			minZoom = Float.parseFloat(d.getString("minZoomLevel"));
 		}
 	}
 

--- a/android/src/ti/map/ViewProxy.java
+++ b/android/src/ti/map/ViewProxy.java
@@ -698,6 +698,10 @@ public class ViewProxy extends TiViewProxy implements AnnotationDelegate
 	{
 		if (data instanceof TiFileProxy) {
 			TiBaseFile file = ((TiFileProxy) data).getBaseFile();
+			if (!file.exists()) {
+				Log.e(TAG, "mbtiles not found");
+				return;
+			}
 			MapBoxOfflineTileProvider mbOfflineTileProvider = new MapBoxOfflineTileProvider(file.getNativeFile());
 			TileOverlayOptions tileOverlayOptions = new TileOverlayOptions().tileProvider(mbOfflineTileProvider);
 

--- a/android/src/ti/map/ViewProxy.java
+++ b/android/src/ti/map/ViewProxy.java
@@ -696,13 +696,17 @@ public class ViewProxy extends TiViewProxy implements AnnotationDelegate
 
 	public void handleAddMbtileMap(Object data)
 	{
-		if (data instanceof TiFileProxy) {
-			TiBaseFile file = ((TiFileProxy) data).getBaseFile();
-			if (!file.exists()) {
+		HashMap hm = (HashMap) data;
+		Object file = hm.get("file");
+		int layerIndex = TiConvert.toInt(hm.get("zIndex"), -1);
+
+		if (file instanceof TiFileProxy) {
+			TiBaseFile baseFile = ((TiFileProxy) file).getBaseFile();
+			if (!baseFile.exists()) {
 				Log.e(TAG, "mbtiles not found");
 				return;
 			}
-			MapBoxOfflineTileProvider mbOfflineTileProvider = new MapBoxOfflineTileProvider(file.getNativeFile());
+			MapBoxOfflineTileProvider mbOfflineTileProvider = new MapBoxOfflineTileProvider(baseFile.getNativeFile());
 			TileOverlayOptions tileOverlayOptions = new TileOverlayOptions().tileProvider(mbOfflineTileProvider);
 
 			TiUIView view = peekView();
@@ -710,7 +714,11 @@ public class ViewProxy extends TiViewProxy implements AnnotationDelegate
 			if (map != null) {
 				map.addTileOverlay(tileOverlayOptions);
 			} else {
-				this.preloadTileOverlayOptionsList.add(tileOverlayOptions);
+				if (layerIndex != -1) {
+					this.preloadTileOverlayOptionsList.add(layerIndex, tileOverlayOptions);
+				} else {
+					this.preloadTileOverlayOptionsList.add(tileOverlayOptions);
+				}
 			}
 		}
 	}

--- a/android/src/ti/map/ViewProxy.java
+++ b/android/src/ti/map/ViewProxy.java
@@ -791,11 +791,8 @@ public class ViewProxy extends TiViewProxy implements AnnotationDelegate
 		}
 	}
 
-	// clang-format off
-	@Kroll.method
 	@Kroll.getProperty
 	public float getMaxZoomLevel()
-	// clang-format on
 	{
 		if (TiApplication.isUIThread()) {
 			return getMaxZoom();
@@ -804,11 +801,8 @@ public class ViewProxy extends TiViewProxy implements AnnotationDelegate
 		}
 	}
 
-	// clang-format off
-	@Kroll.method
 	@Kroll.getProperty
 	public float getMinZoomLevel()
-	// clang-format on
 	{
 		if (TiApplication.isUIThread()) {
 			return getMinZoom();

--- a/android/src/ti/map/ViewProxy.java
+++ b/android/src/ti/map/ViewProxy.java
@@ -714,7 +714,10 @@ public class ViewProxy extends TiViewProxy implements AnnotationDelegate
 			if (map != null) {
 				map.addTileOverlay(tileOverlayOptions);
 			} else {
-				if (layerIndex != -1) {
+				if (layerIndex > -1) {
+					if (layerIndex >= this.preloadTileOverlayOptionsList.size()) {
+						layerIndex = this.preloadTileOverlayOptionsList.size();
+					}
 					this.preloadTileOverlayOptionsList.add(layerIndex, tileOverlayOptions);
 				} else {
 					this.preloadTileOverlayOptionsList.add(tileOverlayOptions);

--- a/android/src/ti/map/ViewProxy.java
+++ b/android/src/ti/map/ViewProxy.java
@@ -664,6 +664,12 @@ public class ViewProxy extends TiViewProxy implements AnnotationDelegate
 		}
 	}
 
+	@Kroll.getProperty
+	public int getTileOverlaySize()
+	{
+		return this.preloadTileOverlayOptionsList.size();
+	}
+
 	@Kroll.method
 	public void addRoute(RouteProxy route)
 	{

--- a/apidoc/View.yml
+++ b/apidoc/View.yml
@@ -709,9 +709,9 @@ properties:
     platforms: [android]
 
   - name: maxZoomLevel
-    summary: Returns the maximum zoom level available at the current camera position.
+    summary: Maximum zoom level available at the current camera position.
     description: |
-        Returns the maximum zoom level for the current camera position.
+        Set and returns the maximum zoom level for the current camera position.
         This takes into account what map type is currently being used.
         For example, satellite or terrain may have a lower max zoom level than the base map tiles.
 
@@ -720,18 +720,19 @@ properties:
     type: Number
     platforms: [android]
     permission: read-only
+    availability: creation
 
   - name: minZoomLevel
-    summary: Returns the minimum zoom level available at the current camera position.
+    summary: Minimum zoom level available at the current camera position.
     description: |
-        Returns the minimum zoom level. This is the same for every location (unlike the maximum zoom level)
+        Set and returns the minimum zoom level. This is the same for every location (unlike the maximum zoom level)
         but may vary between devices and map sizes.
 
         This will only give the correct value after the 'complete' event is fired.
     since: "3.2.3"
     type: Number
     platforms: [android]
-    permission: read-only
+    availability: creation
 
   - name: minClusterSize
     summary: Sets the minium size of a cluster.


### PR DESCRIPTION
Adding mbtile support to load offline map tiles. mbtiles loader from https://github.com/OnlyInAmerica/android-gmaps-addons

`Adria` file from https://wiki.openstreetmap.org/wiki/MBTiles

```js
const Map = require('ti.map');
const win = Titanium.UI.createWindow({});
const mapview = Map.createView({
	mapType: Map.TYPE_NONE,
	minZoomLevel: 10,
	maxZoomLevel: 14,
	region: {
		latitude: 45.18144862950657,
		longitude: 12.980699725449085,
		latitudeDelta: 0.10,
		longitudeDelta: 0.10
	},
});

win.addEventListener("open", function() {
	var mbtiles = Ti.Filesystem.getFile(Ti.Filesystem.applicationDataDirectory, "osm.mbtiles");
	console.log("tileOverlay size before: " + mapview.tileOverlaySize);
	mapview.addMbtileMap({
		file: mbtiles,
		zIndex: 20
	})
	console.log("tileOverlay size after: " + mapview.tileOverlaySize);
})

win.add(mapview)
win.open();
```

[ti.map-android-5.8.0.zip](https://github.com/user-attachments/files/27432164/ti.map-android-5.8.0.zip)

