### PR TITLE
feat(android): expose ImageOverlay image setter

### DIFF
--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 5.6.1
+version: 5.6.2
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: External version of Map module using native Google Maps library

--- a/android/src/ti/map/ImageOverlayProxy.java
+++ b/android/src/ti/map/ImageOverlayProxy.java
@@ -9,19 +9,17 @@ package ti.map;
 
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
-import com.google.android.gms.maps.model.BitmapDescriptor;
+import android.os.AsyncTask;
 import com.google.android.gms.maps.model.BitmapDescriptorFactory;
 import com.google.android.gms.maps.model.GroundOverlay;
 import com.google.android.gms.maps.model.GroundOverlayOptions;
 import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.LatLngBounds;
-import java.io.IOException;
 import java.net.URL;
 import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.KrollProxy;
 import org.appcelerator.kroll.annotations.Kroll;
 import org.appcelerator.kroll.common.Log;
-import org.appcelerator.kroll.common.TiMessenger;
 import org.appcelerator.titanium.view.TiDrawableReference;
 
 @Kroll.proxy(creatableInModule = MapModule.class)
@@ -29,7 +27,6 @@ public class ImageOverlayProxy extends KrollProxy
 {
 
 	private static final String TAG = "ImageOverlayProxy";
-
 	private static final String PROPERTY_BOUNDS_COORDINATE = "boundsCoordinate";
 	private static final String PROPERTY_IMAGE = "image";
 	private static final String PROPERTY_TOP_LEFT = "topLeft";
@@ -55,10 +52,7 @@ public class ImageOverlayProxy extends KrollProxy
 	@Kroll.setProperty
 	public void setImage(Object image)
 	{
-		TiDrawableReference source = TiDrawableReference.fromObject(this, image);
-		if (!source.isTypeNull()) {
-			groundOverlay.setImage(BitmapDescriptorFactory.fromBitmap(source.getBitmap()));
-		}
+		handleImage(image);
 	}
 
 	public GroundOverlay getGroundOverlay()
@@ -87,10 +81,28 @@ public class ImageOverlayProxy extends KrollProxy
 
 	private void handleImage(Object image)
 	{
-		TiDrawableReference source = TiDrawableReference.fromObject(this, image);
-		if (!source.isTypeNull()) {
-			BitmapDescriptor bitmapDescriptor = BitmapDescriptorFactory.fromBitmap(source.getBitmap());
-			groundOverlayOptions.image(bitmapDescriptor);
+		if (image.toString().contains("https://") || image.toString().contains("http://")) {
+			// remote image
+			try {
+				Bitmap bmp = new DownloadImage().execute(image.toString()).get();
+				if (groundOverlay != null) {
+					groundOverlay.setImage(BitmapDescriptorFactory.fromBitmap(bmp));
+				} else {
+					groundOverlayOptions.image(BitmapDescriptorFactory.fromBitmap(bmp));
+				}
+			} catch (Exception ex) {
+				Log.e(TAG, "Error: " + ex.toString());
+			}
+		} else {
+			// local image
+			TiDrawableReference source = TiDrawableReference.fromObject(this, image);
+			if (!source.isTypeNull()) {
+				if (groundOverlay != null) {
+					groundOverlay.setImage(BitmapDescriptorFactory.fromBitmap(source.getBitmap()));
+				} else {
+					groundOverlayOptions.image(BitmapDescriptorFactory.fromBitmap(source.getBitmap()));
+				}
+			}
 		}
 	}
 
@@ -103,5 +115,20 @@ public class ImageOverlayProxy extends KrollProxy
 	public String getApiName()
 	{
 		return "Ti.Map.ImageOverlay";
+	}
+
+	class DownloadImage extends AsyncTask<String, Void, Bitmap>
+	{
+		protected Bitmap doInBackground(String... urls)
+		{
+			try {
+				URL url = new URL(urls[0]);
+				Bitmap bmp = BitmapFactory.decodeStream(url.openConnection().getInputStream());
+				return bmp;
+			} catch (Exception ex) {
+				Log.e(TAG, "Download error: " + ex.toString());
+				return null;
+			}
+		}
 	}
 }

--- a/android/src/ti/map/ImageOverlayProxy.java
+++ b/android/src/ti/map/ImageOverlayProxy.java
@@ -7,15 +7,21 @@
 
 package ti.map;
 
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
 import com.google.android.gms.maps.model.BitmapDescriptor;
 import com.google.android.gms.maps.model.BitmapDescriptorFactory;
 import com.google.android.gms.maps.model.GroundOverlay;
 import com.google.android.gms.maps.model.GroundOverlayOptions;
 import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.LatLngBounds;
+import java.io.IOException;
+import java.net.URL;
 import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.KrollProxy;
 import org.appcelerator.kroll.annotations.Kroll;
+import org.appcelerator.kroll.common.Log;
+import org.appcelerator.kroll.common.TiMessenger;
 import org.appcelerator.titanium.view.TiDrawableReference;
 
 @Kroll.proxy(creatableInModule = MapModule.class)
@@ -43,6 +49,15 @@ public class ImageOverlayProxy extends KrollProxy
 		}
 		if (dict.containsKeyAndNotNull(PROPERTY_IMAGE)) {
 			handleImage(dict.get(PROPERTY_IMAGE));
+		}
+	}
+
+	@Kroll.setProperty
+	public void setImage(Object image)
+	{
+		TiDrawableReference source = TiDrawableReference.fromObject(this, image);
+		if (!source.isTypeNull()) {
+			groundOverlay.setImage(BitmapDescriptorFactory.fromBitmap(source.getBitmap()));
 		}
 	}
 


### PR DESCRIPTION
Exposes the `image` setter of an ImageOverlay and you can use external URLs now:

```js
var Map = require('ti.map');
var win = Titanium.UI.createWindow();

var mapview = Map.createView({
	mapType: Map.NORMAL_TYPE,
	region: {
		latitude: 34.4311,
		longitude: -118.6012,
		latitudeDelta: 0.01,
		longitudeDelta: 0.01
	},
	animate: true,
	regionFit: true,
	userLocation: true,
});

let imgOverlay = Map.createImageOverlay({
	image: "https://picsum.photos/200/200",
	boundsCoordinate: {
		topLeft: {
			latitude: 34.4311,
			longitude: -118.6012
		},
		bottomRight: {
			latitude: 34.4194,
			longitude: -118.5912
		},
	},
})
mapview.addImageOverlays([imgOverlay]);
setTimeout(function() {
	imgOverlay.image = "/image2.png";
}, 2000);
win.add(mapview);
win.open();
```

* add image: image2.png
* extern URL will be shown
* image2 will be shown after 2 seconds


[ti.map-android-5.6.2.zip](https://github.com/user-attachments/files/18628768/ti.map-android-5.6.2.zip)


Merge https://github.com/tidev/ti.map/pull/678 first for workflow and map update