### PR TITLE
feat(android): change from Fragment to a normal View

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,10 +1,10 @@
 
 dependencies {
 	// https://developers.google.com/android/guides/releases
-	implementation 'com.google.android.gms:play-services-maps:18.1.0'
+	implementation 'com.google.android.gms:play-services-maps:19.2.0'
 
 	// https://github.com/googlemaps/android-maps-utils/releases
-	implementation 'com.google.maps.android:android-maps-utils:3.5.3'
+	implementation 'com.google.maps.android:android-maps-utils:3.9.0'
 
 	// https://developer.android.com/jetpack/androidx/releases/fragment
 	implementation 'androidx.fragment:fragment:1.5.7'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,10 +1,10 @@
 
 dependencies {
 	// https://developers.google.com/android/guides/releases
-	implementation 'com.google.android.gms:play-services-maps:19.2.0'
+	implementation 'com.google.android.gms:play-services-maps:20.0.0'
 
 	// https://github.com/googlemaps/android-maps-utils/releases
-	implementation 'com.google.maps.android:android-maps-utils:3.14.0'
+	implementation 'com.google.maps.android:android-maps-utils:3.16.2'
 
 	// https://developer.android.com/jetpack/androidx/releases/fragment
 	implementation 'androidx.fragment:fragment:1.7.1'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,8 +4,8 @@ dependencies {
 	implementation 'com.google.android.gms:play-services-maps:20.0.0'
 
 	// https://github.com/googlemaps/android-maps-utils/releases
-	implementation 'com.google.maps.android:android-maps-utils:3.16.2'
+	implementation 'com.google.maps.android:android-maps-utils:3.16.0'
 
 	// https://developer.android.com/jetpack/androidx/releases/fragment
-	implementation 'androidx.fragment:fragment:1.7.1'
+	implementation 'androidx.fragment:fragment:1.8.9'
 }

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 5.7.0
+version: 6.0.0
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: External version of Map module using native Google Maps library

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 5.6.1
+version: 5.7.0
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: External version of Map module using native Google Maps library
@@ -15,5 +15,5 @@ name: map
 moduleid: ti.map
 guid: f0d8fd44-86d2-4730-b67d-bd454577aeee
 platform: android
-minsdk: 9.0.0
+minsdk: 12.7.0
 respackage: com.google.android.gms

--- a/android/src/ti/map/AnnotationProxy.java
+++ b/android/src/ti/map/AnnotationProxy.java
@@ -8,6 +8,7 @@ package ti.map;
 
 import android.animation.ObjectAnimator;
 import android.animation.TypeEvaluator;
+import android.app.Activity;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.os.Message;
@@ -444,9 +445,12 @@ public class AnnotationProxy extends KrollProxy
 			TiDimension widthDimension = new TiDimension(defaultIconImageWidth, TiDimension.TYPE_UNDEFINED);
 			TiDimension heightDimension = new TiDimension(defaultIconImageHeight, TiDimension.TYPE_UNDEFINED);
 			// TiDimension needs a view to grab the window manager, so we'll just use the decorview of the current window
-			View view = TiApplication.getAppCurrentActivity().getWindow().getDecorView();
-			iconImageWidth = widthDimension.getAsPixels(view);
-			iconImageHeight = heightDimension.getAsPixels(view);
+			Activity activity = TiApplication.getAppCurrentActivity();
+			if (activity != null) {
+				View view = activity.getWindow().getDecorView();
+				iconImageWidth = widthDimension.getAsPixels(view);
+				iconImageHeight = heightDimension.getAsPixels(view);
+			}
 		}
 	}
 

--- a/android/src/ti/map/TiClusterRenderer.java
+++ b/android/src/ti/map/TiClusterRenderer.java
@@ -1,5 +1,6 @@
 package ti.map;
 
+import android.app.Activity;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.view.View;
@@ -130,9 +131,12 @@ public class TiClusterRenderer extends DefaultClusterRenderer<TiMarker>
 		} else { // default maker icon
 			TiDimension widthDimension = new TiDimension(defaultIconImageWidth, TiDimension.TYPE_UNDEFINED);
 			TiDimension heightDimension = new TiDimension(defaultIconImageHeight, TiDimension.TYPE_UNDEFINED);
-			View view = TiApplication.getAppCurrentActivity().getWindow().getDecorView();
-			iconImageWidth = widthDimension.getAsPixels(view);
-			iconImageHeight = heightDimension.getAsPixels(view);
+			Activity activity = TiApplication.getAppCurrentActivity();
+			if (activity != null) {
+				View view = activity.getWindow().getDecorView();
+				iconImageWidth = widthDimension.getAsPixels(view);
+				iconImageHeight = heightDimension.getAsPixels(view);
+			}
 		}
 	}
 }

--- a/android/src/ti/map/TiMapInfoWindow.java
+++ b/android/src/ti/map/TiMapInfoWindow.java
@@ -219,32 +219,36 @@ public class TiMapInfoWindow extends RelativeLayout
 			evCopy.offsetLocation(-markerPoint.x + infoWindowHalfWidth,
 								  -markerPoint.y + infoWindowHeight + iconImageHeight);
 
-			int x = (int) evCopy.getX();
-			int y = (int) evCopy.getY();
+			try {
+				int x = (int) evCopy.getX();
+				int y = (int) evCopy.getY();
 
-			Rect hitRect = new Rect();
+				Rect hitRect = new Rect();
 
-			int count = clicksourceList.length;
-			for (int i = 0; i < count; i++) {
-				View v = clicksourceList[i];
-				String tag = (String) v.getTag();
-				if (v.getVisibility() == View.VISIBLE && tag != null) {
-					v.getHitRect(hitRect);
+				int count = clicksourceList.length;
+				for (int i = 0; i < count; i++) {
+					View v = clicksourceList[i];
+					String tag = (String) v.getTag();
+					if (v.getVisibility() == View.VISIBLE && tag != null) {
+						v.getHitRect(hitRect);
 
-					// The title and subtitle are the children of a relative layout which is the child of this.
-					if (tag.equals(TiC.PROPERTY_TITLE) || tag.equals(TiC.PROPERTY_SUBTITLE)) {
-						Rect textLayoutRect = new Rect();
-						((ViewGroup) (v.getParent())).getHitRect(textLayoutRect);
-						hitRect.offset(textLayoutRect.left, textLayoutRect.top);
-					}
+						// The title and subtitle are the children of a relative layout which is the child of this.
+						if (tag.equals(TiC.PROPERTY_TITLE) || tag.equals(TiC.PROPERTY_SUBTITLE)) {
+							Rect textLayoutRect = new Rect();
+							((ViewGroup) (v.getParent())).getHitRect(textLayoutRect);
+							hitRect.offset(textLayoutRect.left, textLayoutRect.top);
+						}
 
-					if (hitRect.contains(x, y)) {
-						setClickSource(tag);
-						return;
+						if (hitRect.contains(x, y)) {
+							setClickSource(tag);
+							return;
+						}
 					}
 				}
+				setClickSource(null);
+			} finally {
+				evCopy.recycle();
 			}
-			setClickSource(null);
 		}
 	}
 

--- a/android/src/ti/map/TiUIMapView.java
+++ b/android/src/ti/map/TiUIMapView.java
@@ -21,13 +21,11 @@ import android.view.MotionEvent;
 import android.view.SurfaceView;
 import android.view.View;
 import android.view.ViewGroup;
-import androidx.fragment.app.Fragment;
 import com.google.android.gms.maps.CameraUpdate;
 import com.google.android.gms.maps.CameraUpdateFactory;
 import com.google.android.gms.maps.GoogleMap;
-import com.google.android.gms.maps.GoogleMapOptions;
+import com.google.android.gms.maps.MapView;
 import com.google.android.gms.maps.OnMapReadyCallback;
-import com.google.android.gms.maps.SupportMapFragment;
 import com.google.android.gms.maps.model.CameraPosition;
 import com.google.android.gms.maps.model.Circle;
 import com.google.android.gms.maps.model.LatLng;
@@ -46,6 +44,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.KrollProxy;
+import org.appcelerator.kroll.KrollProxyListener;
 import org.appcelerator.kroll.common.Log;
 import org.appcelerator.titanium.TiApplication;
 import org.appcelerator.titanium.TiBlob;
@@ -53,7 +52,8 @@ import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.io.TiFileFactory;
 import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.util.TiConvert;
-import org.appcelerator.titanium.view.TiUIFragment;
+import org.appcelerator.titanium.view.TiCompositeLayout;
+import org.appcelerator.titanium.view.TiUIView;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -62,7 +62,7 @@ import ti.map.Shape.Boundary;
 import ti.map.Shape.IShape;
 import ti.map.Shape.PolylineBoundary;
 
-public class TiUIMapView extends TiUIFragment
+public class TiUIMapView extends TiUIView
 	implements GoogleMap.OnMarkerClickListener, GoogleMap.OnMapClickListener, GoogleMap.OnMarkerDragListener,
 			   GoogleMap.OnInfoWindowClickListener, GoogleMap.InfoWindowAdapter, GoogleMap.OnMapLongClickListener,
 			   GoogleMap.OnMapLoadedCallback, OnMapReadyCallback, GoogleMap.OnCameraMoveStartedListener,
@@ -79,6 +79,7 @@ public class TiUIMapView extends TiUIFragment
 	protected LatLngBounds preLayoutUpdateBounds;
 	protected ArrayList<TiMarker> timarkers;
 	protected AnnotationProxy selectedAnnotation;
+	private MapView mMapView;
 
 	private ArrayList<CircleProxy> currentCircles;
 	private ArrayList<PolygonProxy> currentPolygons;
@@ -89,9 +90,25 @@ public class TiUIMapView extends TiUIFragment
 	private MarkerManager mMarkerManager;
 	private MarkerManager.Collection collection;
 
-	public TiUIMapView(final TiViewProxy proxy, Activity activity)
+	public TiUIMapView(TiViewProxy proxy)
 	{
-		super(proxy, activity);
+		super(proxy);
+		mMapView = new MapView(proxy.getActivity());
+		mMapView.onCreate(null);
+		mMapView.onResume();
+
+		mMapView.getMapAsync(this);
+
+		TiCompositeLayout container = new TiCompositeLayout(proxy.getActivity(), proxy) {
+			@Override
+			public boolean dispatchTouchEvent(MotionEvent ev)
+			{
+				return interceptTouchEvent(ev) || super.dispatchTouchEvent(ev);
+			}
+		};
+		container.addView(mMapView);
+		setNativeView(container);
+
 		timarkers = new ArrayList<TiMarker>();
 		currentCircles = new ArrayList<CircleProxy>();
 		currentPolygons = new ArrayList<PolygonProxy>();
@@ -119,30 +136,6 @@ public class TiUIMapView extends TiUIFragment
 			for (int i = 0; i < viewGroup.getChildCount(); i++) {
 				setBackgroundTransparent(viewGroup.getChildAt(i));
 			}
-		}
-	}
-
-	@Override
-	protected Fragment createFragment()
-	{
-		if (proxy == null) {
-			Fragment map = SupportMapFragment.newInstance();
-			if (map instanceof SupportMapFragment) {
-				((SupportMapFragment) map).getMapAsync(this);
-			}
-			return map;
-		} else {
-			boolean zOrderOnTop = TiConvert.toBoolean(proxy.getProperty(MapModule.PROPERTY_ZORDER_ON_TOP), false);
-			GoogleMapOptions gOptions = new GoogleMapOptions();
-			gOptions.zOrderOnTop(zOrderOnTop);
-			if (this.liteMode) {
-				gOptions.liteMode(true);
-			}
-			Fragment map = SupportMapFragment.newInstance(gOptions);
-			if (map instanceof SupportMapFragment) {
-				((SupportMapFragment) map).getMapAsync(this);
-			}
-			return map;
 		}
 	}
 
@@ -1374,7 +1367,6 @@ public class TiUIMapView extends TiUIFragment
 
 	// Intercept the touch event to find out the correct clicksource if clicking
 	// on the info window.
-	@Override
 	protected boolean interceptTouchEvent(MotionEvent ev)
 	{
 		if (ev.getAction() == MotionEvent.ACTION_UP && selectedAnnotation != null) {
@@ -1446,5 +1438,19 @@ public class TiUIMapView extends TiUIFragment
 	public boolean onClusterItemClick(TiMarker tiMarker)
 	{
 		return onMarkerClick(tiMarker.getMarker());
+	}
+
+	public void onResume()
+	{
+		if (mMapView != null) {
+			mMapView.onResume();
+		}
+	}
+
+	public void onDestroy()
+	{
+		if (mMapView != null) {
+			mMapView.onDestroy();
+		}
 	}
 }

--- a/android/src/ti/map/TiUIMapView.java
+++ b/android/src/ti/map/TiUIMapView.java
@@ -49,8 +49,10 @@ import org.appcelerator.kroll.KrollProxy;
 import org.appcelerator.kroll.KrollProxyListener;
 import org.appcelerator.kroll.common.Log;
 import org.appcelerator.titanium.TiApplication;
+import org.appcelerator.titanium.TiBaseActivity;
 import org.appcelerator.titanium.TiBlob;
 import org.appcelerator.titanium.TiC;
+import org.appcelerator.titanium.TiLifecycle;
 import org.appcelerator.titanium.io.TiFileFactory;
 import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.util.TiConvert;
@@ -69,7 +71,8 @@ public class TiUIMapView extends TiUIView
 			   GoogleMap.OnInfoWindowClickListener, GoogleMap.InfoWindowAdapter, GoogleMap.OnMapLongClickListener,
 			   GoogleMap.OnMapLoadedCallback, OnMapReadyCallback, GoogleMap.OnCameraMoveStartedListener,
 			   GoogleMap.OnCameraMoveListener, GoogleMap.OnCameraIdleListener, GoogleMap.OnMyLocationChangeListener,
-			   ClusterManager.OnClusterClickListener<TiMarker>, ClusterManager.OnClusterItemClickListener<TiMarker>
+			   ClusterManager.OnClusterClickListener<TiMarker>, ClusterManager.OnClusterItemClickListener<TiMarker>,
+			   TiLifecycle.OnInstanceStateEvent
 {
 
 	public static final String DEFAULT_COLLECTION_ID = "defaultCollection";
@@ -83,6 +86,7 @@ public class TiUIMapView extends TiUIView
 	protected ArrayList<TiMarker> timarkers;
 	protected AnnotationProxy selectedAnnotation;
 	private MapView mMapView;
+	private boolean mapViewInitialized = false;
 
 	private ArrayList<CircleProxy> currentCircles;
 	private ArrayList<PolygonProxy> currentPolygons;
@@ -108,6 +112,7 @@ public class TiUIMapView extends TiUIView
 		mMapView = new MapView(proxy.getActivity(), options);
 		mMapView.onCreate(null);
 		mMapView.onResume();
+		mapViewInitialized = true;
 
 		mMapView.getMapAsync(this);
 
@@ -127,6 +132,11 @@ public class TiUIMapView extends TiUIView
 		currentPolylines = new ArrayList<PolylineProxy>();
 		currentImageOverlays = new ArrayList<ImageOverlayProxy>();
 		proxy.setProperty(MapModule.PROPERTY_INDOOR_ENABLED, true);
+
+		Activity activity = proxy.getActivity();
+		if (activity instanceof TiBaseActivity) {
+			((TiBaseActivity) activity).addOnInstanceStateEventListener(this);
+		}
 	}
 
 	/**
@@ -1455,9 +1465,10 @@ public class TiUIMapView extends TiUIView
 	public void onResume()
 	{
 		if (mMapView != null) {
-			if (pendingSavedState != null) {
+			if (!mapViewInitialized && pendingSavedState != null) {
 				mMapView.onCreate(pendingSavedState);
 				pendingSavedState = null;
+				mapViewInitialized = true;
 			}
 			mMapView.onResume();
 		}
@@ -1467,6 +1478,10 @@ public class TiUIMapView extends TiUIView
 	{
 		if (mMapView != null) {
 			mMapView.onDestroy();
+		}
+		Activity activity = proxy != null ? proxy.getActivity() : null;
+		if (activity instanceof TiBaseActivity) {
+			((TiBaseActivity) activity).removeOnInstanceStateEventListener(this);
 		}
 	}
 
@@ -1494,5 +1509,21 @@ public class TiUIMapView extends TiUIView
 	public void setSavedInstanceState(Bundle savedState)
 	{
 		this.pendingSavedState = savedState;
+	}
+
+	@Override
+	public void onSaveInstanceState(Bundle bundle)
+	{
+		if (mMapView != null) {
+			mMapView.onSaveInstanceState(bundle);
+		}
+	}
+
+	@Override
+	public void onRestoreInstanceState(Bundle bundle)
+	{
+		if (mMapView != null) {
+			pendingSavedState = bundle;
+		}
 	}
 }

--- a/android/src/ti/map/TiUIMapView.java
+++ b/android/src/ti/map/TiUIMapView.java
@@ -110,6 +110,7 @@ public class TiUIMapView extends TiUIView
 		}
 		mMapView = new MapView(proxy.getActivity(), options);
 		mMapView.onCreate(null);
+		mMapView.onStart();
 		mMapView.onResume();
 
 		mMapView.getMapAsync(this);
@@ -1324,6 +1325,17 @@ public class TiUIMapView extends TiUIView
 		timarkers.clear();
 		mClusterManager = null;
 		mMarkerManager = null;
+
+		if (mMapView != null) {
+			mMapView.onDestroy();
+			mMapView = null;
+		}
+
+		Activity activity = proxy != null ? proxy.getActivity() : null;
+		if (activity instanceof TiBaseActivity) {
+			((TiBaseActivity) activity).removeOnInstanceStateEventListener(this);
+		}
+
 		super.release();
 	}
 
@@ -1466,6 +1478,7 @@ public class TiUIMapView extends TiUIView
 			if (pendingSavedState != null) {
 				mMapView.onDestroy();
 				mMapView.onCreate(pendingSavedState);
+				mMapView.onStart();
 				pendingSavedState = null;
 			}
 			mMapView.onResume();

--- a/android/src/ti/map/TiUIMapView.java
+++ b/android/src/ti/map/TiUIMapView.java
@@ -24,6 +24,7 @@ import android.view.ViewGroup;
 import com.google.android.gms.maps.CameraUpdate;
 import com.google.android.gms.maps.CameraUpdateFactory;
 import com.google.android.gms.maps.GoogleMap;
+import com.google.android.gms.maps.GoogleMapOptions;
 import com.google.android.gms.maps.MapView;
 import com.google.android.gms.maps.OnMapReadyCallback;
 import com.google.android.gms.maps.model.CameraPosition;
@@ -93,7 +94,16 @@ public class TiUIMapView extends TiUIView
 	public TiUIMapView(TiViewProxy proxy)
 	{
 		super(proxy);
-		mMapView = new MapView(proxy.getActivity());
+		GoogleMapOptions options = new GoogleMapOptions();
+		Object liteModeValue = proxy.getProperty(MapModule.PROPERTY_LITE_MODE);
+		if (liteModeValue != null && TiConvert.toBoolean(liteModeValue, false)) {
+			options.liteMode(true);
+		}
+		Object zOrderOnTopValue = proxy.getProperty(MapModule.PROPERTY_ZORDER_ON_TOP);
+		if (zOrderOnTopValue != null && TiConvert.toBoolean(zOrderOnTopValue, false)) {
+			options.zOrderOnTop(true);
+		}
+		mMapView = new MapView(proxy.getActivity(), options);
 		mMapView.onCreate(null);
 		mMapView.onResume();
 

--- a/android/src/ti/map/TiUIMapView.java
+++ b/android/src/ti/map/TiUIMapView.java
@@ -1504,6 +1504,13 @@ public class TiUIMapView extends TiUIView
 		}
 	}
 
+	public void onLowMemory()
+	{
+		if (mMapView != null) {
+			mMapView.onLowMemory();
+		}
+	}
+
 	public void setSavedInstanceState(Bundle savedState)
 	{
 		this.pendingSavedState = savedState;

--- a/android/src/ti/map/TiUIMapView.java
+++ b/android/src/ti/map/TiUIMapView.java
@@ -86,7 +86,6 @@ public class TiUIMapView extends TiUIView
 	protected ArrayList<TiMarker> timarkers;
 	protected AnnotationProxy selectedAnnotation;
 	private MapView mMapView;
-	private boolean mapViewInitialized = false;
 
 	private ArrayList<CircleProxy> currentCircles;
 	private ArrayList<PolygonProxy> currentPolygons;
@@ -112,7 +111,6 @@ public class TiUIMapView extends TiUIView
 		mMapView = new MapView(proxy.getActivity(), options);
 		mMapView.onCreate(null);
 		mMapView.onResume();
-		mapViewInitialized = true;
 
 		mMapView.getMapAsync(this);
 
@@ -1465,10 +1463,10 @@ public class TiUIMapView extends TiUIView
 	public void onResume()
 	{
 		if (mMapView != null) {
-			if (!mapViewInitialized && pendingSavedState != null) {
+			if (pendingSavedState != null) {
+				mMapView.onDestroy();
 				mMapView.onCreate(pendingSavedState);
 				pendingSavedState = null;
-				mapViewInitialized = true;
 			}
 			mMapView.onResume();
 		}

--- a/android/src/ti/map/TiUIMapView.java
+++ b/android/src/ti/map/TiUIMapView.java
@@ -17,6 +17,7 @@ import android.graphics.Color;
 import android.graphics.Point;
 import android.location.Location;
 import android.os.Build;
+import android.os.Bundle;
 import android.view.MotionEvent;
 import android.view.SurfaceView;
 import android.view.View;
@@ -78,6 +79,7 @@ public class TiUIMapView extends TiUIView
 	protected boolean preLayout = true;
 	protected boolean liteMode = false;
 	protected LatLngBounds preLayoutUpdateBounds;
+	private Bundle pendingSavedState;
 	protected ArrayList<TiMarker> timarkers;
 	protected AnnotationProxy selectedAnnotation;
 	private MapView mMapView;
@@ -1453,6 +1455,10 @@ public class TiUIMapView extends TiUIView
 	public void onResume()
 	{
 		if (mMapView != null) {
+			if (pendingSavedState != null) {
+				mMapView.onCreate(pendingSavedState);
+				pendingSavedState = null;
+			}
 			mMapView.onResume();
 		}
 	}
@@ -1462,5 +1468,31 @@ public class TiUIMapView extends TiUIView
 		if (mMapView != null) {
 			mMapView.onDestroy();
 		}
+	}
+
+	public void onStart()
+	{
+		if (mMapView != null) {
+			mMapView.onStart();
+		}
+	}
+
+	public void onPause()
+	{
+		if (mMapView != null) {
+			mMapView.onPause();
+		}
+	}
+
+	public void onStop()
+	{
+		if (mMapView != null) {
+			mMapView.onStop();
+		}
+	}
+
+	public void setSavedInstanceState(Bundle savedState)
+	{
+		this.pendingSavedState = savedState;
 	}
 }

--- a/android/src/ti/map/TiUIMapView.java
+++ b/android/src/ti/map/TiUIMapView.java
@@ -1504,13 +1504,6 @@ public class TiUIMapView extends TiUIView
 		}
 	}
 
-	public void onLowMemory()
-	{
-		if (mMapView != null) {
-			mMapView.onLowMemory();
-		}
-	}
-
 	public void setSavedInstanceState(Bundle savedState)
 	{
 		this.pendingSavedState = savedState;

--- a/android/src/ti/map/TiUIMapView.java
+++ b/android/src/ti/map/TiUIMapView.java
@@ -661,7 +661,6 @@ public class TiUIMapView extends TiUIView
 				tiMarker = new TiMarker(null, annotation);
 				if (mClusterManager != null) {
 					mClusterManager.addItem((TiMarker) tiMarker);
-					mClusterManager.cluster();
 				}
 			}
 			annotation.setTiMarker(tiMarker);
@@ -703,7 +702,6 @@ public class TiUIMapView extends TiUIView
 		// clear cluster markers
 		if (mClusterManager != null) {
 			mClusterManager.clearItems();
-			mClusterManager.cluster();
 		}
 	}
 
@@ -732,7 +730,6 @@ public class TiUIMapView extends TiUIView
 		if (timarker != null && timarkers.contains(timarker)) {
 			if (mClusterManager != null) {
 				mClusterManager.removeItem(timarker);
-				mClusterManager.cluster();
 			}
 			if (timarker.getMarker() != null) {
 				timarker.getMarker().remove();
@@ -1079,27 +1076,24 @@ public class TiUIMapView extends TiUIView
 
 	private String loadJSONFromAsset(String filename)
 	{
-		String json = null;
-
 		try {
 			String url = proxy.resolveUrl(null, filename);
-			InputStream inputStream = TiFileFactory.createTitaniumFile(new String[] { url }, false).getInputStream();
-			ByteArrayOutputStream result = new ByteArrayOutputStream();
-			byte[] buffer = new byte[4096];
-			int length;
+			try (InputStream inputStream = TiFileFactory.createTitaniumFile(new String[] { url }, false).getInputStream()) {
+				ByteArrayOutputStream result = new ByteArrayOutputStream();
+				byte[] buffer = new byte[4096];
+				int length;
 
-			while ((length = inputStream.read(buffer)) != -1) {
-				result.write(buffer, 0, length);
+				while ((length = inputStream.read(buffer)) != -1) {
+					result.write(buffer, 0, length);
+				}
+
+				return result.toString("UTF-8");
 			}
-
-			json = result.toString("UTF-8");
-			inputStream.close();
-			result.close();
 		} catch (IOException ex) {
 			Log.e(TAG, "Error opening file: " + ex.getMessage());
 		}
 
-		return json;
+		return null;
 	}
 
 	@Override
@@ -1330,6 +1324,10 @@ public class TiUIMapView extends TiUIView
 		mMarkerManager = null;
 
 		if (mMapView != null) {
+			ViewGroup parent = (ViewGroup) mMapView.getParent();
+			if (parent != null) {
+				parent.removeView(mMapView);
+			}
 			mMapView.onDestroy();
 			mMapView = null;
 		}

--- a/android/src/ti/map/TiUIMapView.java
+++ b/android/src/ti/map/TiUIMapView.java
@@ -82,7 +82,6 @@ public class TiUIMapView extends TiUIView
 	protected boolean preLayout = true;
 	protected boolean liteMode = false;
 	protected LatLngBounds preLayoutUpdateBounds;
-	private Bundle pendingSavedState;
 	protected ArrayList<TiMarker> timarkers;
 	protected AnnotationProxy selectedAnnotation;
 	private MapView mMapView;
@@ -108,8 +107,9 @@ public class TiUIMapView extends TiUIView
 		if (zOrderOnTopValue != null && TiConvert.toBoolean(zOrderOnTopValue, false)) {
 			options.zOrderOnTop(true);
 		}
+		Bundle savedState = (proxy instanceof ViewProxy) ? ((ViewProxy) proxy).getSavedInstanceState() : null;
 		mMapView = new MapView(proxy.getActivity(), options);
-		mMapView.onCreate(null);
+		mMapView.onCreate(savedState);
 		mMapView.onStart();
 		mMapView.onResume();
 
@@ -637,6 +637,11 @@ public class TiUIMapView extends TiUIView
 
 	protected void addAnnotation(AnnotationProxy annotation)
 	{
+		addAnnotation(annotation, true);
+	}
+
+	private void addAnnotation(AnnotationProxy annotation, boolean recluster)
+	{
 		if (map == null) {
 			return;
 		}
@@ -661,6 +666,9 @@ public class TiUIMapView extends TiUIView
 				tiMarker = new TiMarker(null, annotation);
 				if (mClusterManager != null) {
 					mClusterManager.addItem((TiMarker) tiMarker);
+					if (recluster) {
+						mClusterManager.cluster();
+					}
 				}
 			}
 			annotation.setTiMarker(tiMarker);
@@ -674,8 +682,11 @@ public class TiUIMapView extends TiUIView
 			Object obj = annotations[i];
 			if (obj instanceof AnnotationProxy) {
 				AnnotationProxy annotation = (AnnotationProxy) obj;
-				addAnnotation(annotation);
+				addAnnotation(annotation, false);
 			}
+		}
+		if (mClusterManager != null) {
+			mClusterManager.cluster();
 		}
 	}
 
@@ -702,6 +713,7 @@ public class TiUIMapView extends TiUIView
 		// clear cluster markers
 		if (mClusterManager != null) {
 			mClusterManager.clearItems();
+			mClusterManager.cluster();
 		}
 	}
 
@@ -730,6 +742,7 @@ public class TiUIMapView extends TiUIView
 		if (timarker != null && timarkers.contains(timarker)) {
 			if (mClusterManager != null) {
 				mClusterManager.removeItem(timarker);
+				mClusterManager.cluster();
 			}
 			if (timarker.getMarker() != null) {
 				timarker.getMarker().remove();
@@ -1078,7 +1091,8 @@ public class TiUIMapView extends TiUIView
 	{
 		try {
 			String url = proxy.resolveUrl(null, filename);
-			try (InputStream inputStream = TiFileFactory.createTitaniumFile(new String[] { url }, false).getInputStream()) {
+			try (InputStream inputStream =
+					 TiFileFactory.createTitaniumFile(new String[] { url }, false).getInputStream()) {
 				ByteArrayOutputStream result = new ByteArrayOutputStream();
 				byte[] buffer = new byte[4096];
 				int length;
@@ -1476,12 +1490,6 @@ public class TiUIMapView extends TiUIView
 	public void onResume()
 	{
 		if (mMapView != null) {
-			if (pendingSavedState != null) {
-				mMapView.onDestroy();
-				mMapView.onCreate(pendingSavedState);
-				mMapView.onStart();
-				pendingSavedState = null;
-			}
 			mMapView.onResume();
 		}
 	}
@@ -1518,11 +1526,6 @@ public class TiUIMapView extends TiUIView
 		}
 	}
 
-	public void setSavedInstanceState(Bundle savedState)
-	{
-		this.pendingSavedState = savedState;
-	}
-
 	@Override
 	public void onSaveInstanceState(Bundle bundle)
 	{
@@ -1534,8 +1537,8 @@ public class TiUIMapView extends TiUIView
 	@Override
 	public void onRestoreInstanceState(Bundle bundle)
 	{
-		if (mMapView != null) {
-			pendingSavedState = bundle;
-		}
+		// Restoring an already-created MapView would require destroying and re-creating it
+		// (and re-fetching the GoogleMap). Instead, the saved state is picked up from
+		// ViewProxy.onCreate() and passed to MapView.onCreate() when the view is built.
 	}
 }

--- a/android/src/ti/map/TiUIMapView.java
+++ b/android/src/ti/map/TiUIMapView.java
@@ -953,6 +953,9 @@ public class TiUIMapView extends TiUIView
 
 	public void addImageOverlay(ImageOverlayProxy proxy)
 	{
+		if (map == null) {
+			return;
+		}
 		proxy.setGroundOverlay(map.addGroundOverlay(proxy.getGroundOverlayOptions()));
 		currentImageOverlays.add(proxy);
 	}

--- a/android/src/ti/map/ViewProxy.java
+++ b/android/src/ti/map/ViewProxy.java
@@ -182,6 +182,16 @@ public class ViewProxy extends TiViewProxy implements AnnotationDelegate
 	}
 
 	@Override
+	public void onLowMemory(Activity activity)
+	{
+		super.onLowMemory(activity);
+		TiUIView view = peekView();
+		if (view instanceof TiUIMapView) {
+			((TiUIMapView) view).onLowMemory();
+		}
+	}
+
+	@Override
 	public boolean handleMessage(Message msg)
 	{
 		AsyncResult result = null;

--- a/android/src/ti/map/ViewProxy.java
+++ b/android/src/ti/map/ViewProxy.java
@@ -182,16 +182,6 @@ public class ViewProxy extends TiViewProxy implements AnnotationDelegate
 	}
 
 	@Override
-	public void onLowMemory(Activity activity)
-	{
-		super.onLowMemory(activity);
-		TiUIView view = peekView();
-		if (view instanceof TiUIMapView) {
-			((TiUIMapView) view).onLowMemory();
-		}
-	}
-
-	@Override
 	public boolean handleMessage(Message msg)
 	{
 		AsyncResult result = null;

--- a/android/src/ti/map/ViewProxy.java
+++ b/android/src/ti/map/ViewProxy.java
@@ -127,6 +127,7 @@ public class ViewProxy extends TiViewProxy implements AnnotationDelegate
 		super.onCreate(activity, savedInstanceState);
 		TiUIView view = peekView();
 		if (view instanceof TiUIMapView) {
+			((TiUIMapView) view).setSavedInstanceState(savedInstanceState);
 			((TiUIMapView) view).onResume();
 		}
 	}
@@ -138,6 +139,36 @@ public class ViewProxy extends TiViewProxy implements AnnotationDelegate
 		TiUIView view = peekView();
 		if (view instanceof TiUIMapView) {
 			((TiUIMapView) view).onDestroy();
+		}
+	}
+
+	@Override
+	public void onStart(Activity activity)
+	{
+		super.onStart(activity);
+		TiUIView view = peekView();
+		if (view instanceof TiUIMapView) {
+			((TiUIMapView) view).onStart();
+		}
+	}
+
+	@Override
+	public void onPause(Activity activity)
+	{
+		super.onPause(activity);
+		TiUIView view = peekView();
+		if (view instanceof TiUIMapView) {
+			((TiUIMapView) view).onPause();
+		}
+	}
+
+	@Override
+	public void onStop(Activity activity)
+	{
+		super.onStop(activity);
+		TiUIView view = peekView();
+		if (view instanceof TiUIMapView) {
+			((TiUIMapView) view).onStop();
 		}
 	}
 

--- a/android/src/ti/map/ViewProxy.java
+++ b/android/src/ti/map/ViewProxy.java
@@ -7,12 +7,11 @@
 package ti.map;
 
 import android.app.Activity;
+import android.os.Bundle;
 import android.os.Message;
 import com.google.android.gms.maps.CameraUpdate;
 import com.google.android.gms.maps.GoogleMap;
-import com.google.android.gms.maps.MapView;
 import com.google.android.gms.maps.model.LatLng;
-import com.google.android.gms.maps.model.TileOverlay;
 import com.google.android.gms.maps.model.TileOverlayOptions;
 import com.google.maps.android.heatmaps.HeatmapTileProvider;
 import java.util.ArrayList;
@@ -110,7 +109,7 @@ public class ViewProxy extends TiViewProxy implements AnnotationDelegate
 	@Override
 	public TiUIView createView(Activity activity)
 	{
-		return new TiUIMapView(this, activity);
+		return new TiUIMapView(this);
 	}
 
 	public void clearPreloadObjects()
@@ -120,6 +119,26 @@ public class ViewProxy extends TiViewProxy implements AnnotationDelegate
 		preloadPolylines.clear();
 		preloadCircles.clear();
 		preloadTileOverlayOptionsList.clear();
+	}
+
+	@Override
+	public void onCreate(Activity activity, Bundle savedInstanceState)
+	{
+		super.onCreate(activity, savedInstanceState);
+		TiUIView view = peekView();
+		if (view instanceof TiUIMapView) {
+			((TiUIMapView) view).onResume();
+		}
+	}
+
+	@Override
+	public void onDestroy(Activity activity)
+	{
+		super.onDestroy(activity);
+		TiUIView view = peekView();
+		if (view instanceof TiUIMapView) {
+			((TiUIMapView) view).onDestroy();
+		}
 	}
 
 	@Override

--- a/android/src/ti/map/ViewProxy.java
+++ b/android/src/ti/map/ViewProxy.java
@@ -128,7 +128,6 @@ public class ViewProxy extends TiViewProxy implements AnnotationDelegate
 		TiUIView view = peekView();
 		if (view instanceof TiUIMapView) {
 			((TiUIMapView) view).setSavedInstanceState(savedInstanceState);
-			((TiUIMapView) view).onResume();
 		}
 	}
 
@@ -139,6 +138,16 @@ public class ViewProxy extends TiViewProxy implements AnnotationDelegate
 		TiUIView view = peekView();
 		if (view instanceof TiUIMapView) {
 			((TiUIMapView) view).onDestroy();
+		}
+	}
+
+	@Override
+	public void onResume(Activity activity)
+	{
+		super.onResume(activity);
+		TiUIView view = peekView();
+		if (view instanceof TiUIMapView) {
+			((TiUIMapView) view).onResume();
 		}
 	}
 

--- a/android/src/ti/map/ViewProxy.java
+++ b/android/src/ti/map/ViewProxy.java
@@ -1275,10 +1275,12 @@ public class ViewProxy extends TiViewProxy implements AnnotationDelegate
 	{
 		TiUIView view = peekView();
 		if (view instanceof TiUIMapView) {
-			return ((TiUIMapView) view).getMap().getCameraPosition().zoom;
-		} else {
-			return 0;
+			GoogleMap map = ((TiUIMapView) view).getMap();
+			if (map != null && map.getCameraPosition() != null) {
+				return map.getCameraPosition().zoom;
+			}
 		}
+		return 0;
 	}
 
 	@Kroll.method

--- a/android/src/ti/map/ViewProxy.java
+++ b/android/src/ti/map/ViewProxy.java
@@ -89,6 +89,7 @@ public class ViewProxy extends TiViewProxy implements AnnotationDelegate
 	private final ArrayList<CircleProxy> preloadCircles;
 	private final ArrayList<ImageOverlayProxy> preloadOverlaysList;
 	private final ArrayList<TileOverlayOptions> preloadTileOverlayOptionsList;
+	private Bundle savedInstanceState;
 
 	public ViewProxy()
 	{
@@ -126,10 +127,14 @@ public class ViewProxy extends TiViewProxy implements AnnotationDelegate
 	public void onCreate(Activity activity, Bundle savedInstanceState)
 	{
 		super.onCreate(activity, savedInstanceState);
-		TiUIView view = peekView();
-		if (view instanceof TiUIMapView) {
-			((TiUIMapView) view).setSavedInstanceState(savedInstanceState);
-		}
+		// The view does not exist yet at this point. Keep the bundle so TiUIMapView
+		// can pass it to MapView.onCreate() when the view is created.
+		this.savedInstanceState = savedInstanceState;
+	}
+
+	public Bundle getSavedInstanceState()
+	{
+		return savedInstanceState;
 	}
 
 	@Override
@@ -478,11 +483,9 @@ public class ViewProxy extends TiViewProxy implements AnnotationDelegate
 
 	private void handleAddAnnotations(Object[] annotations)
 	{
-		for (int i = 0; i < annotations.length; i++) {
-			Object annotation = annotations[i];
-			if (annotation instanceof AnnotationProxy) {
-				handleAddAnnotation((AnnotationProxy) annotation);
-			}
+		TiUIMapView mapView = (TiUIMapView) peekView();
+		if (mapView.getMap() != null) {
+			mapView.addAnnotations(annotations);
 		}
 	}
 

--- a/android/src/ti/map/ViewProxy.java
+++ b/android/src/ti/map/ViewProxy.java
@@ -118,6 +118,7 @@ public class ViewProxy extends TiViewProxy implements AnnotationDelegate
 		preloadPolygons.clear();
 		preloadPolylines.clear();
 		preloadCircles.clear();
+		preloadOverlaysList.clear();
 		preloadTileOverlayOptionsList.clear();
 	}
 
@@ -1486,6 +1487,7 @@ public class ViewProxy extends TiViewProxy implements AnnotationDelegate
 	@Kroll.method
 	public void removeAllImageOverlays()
 	{
+		TiUIView view = peekView();
 		if (view instanceof TiUIMapView) {
 			if (TiApplication.isUIThread()) {
 				handleRemoveAllImageOverlays();


### PR DESCRIPTION
I think it is currently the only module that uses Fragments instead of a normal view. This had some issues before (ListView header) and it will fix https://github.com/tidev/titanium-sdk/issues/14214

Also matches the same library versions as https://github.com/tidev/ti.map/pull/678 (merge first for the action fixes).

Tested:
* my climbing app which uses clusters, info boxes and static maps
* example code from https://github.com/tidev/titanium-sdk/issues/14214 (new bottom navigation that current crashes because of Fragment issues)
* old ListSection crash example from https://github.com/tidev/titanium-sdk/issues/13243

Changes:
* move from Fragment to normal View
* update libraries
* added some null pointer checks
* Replaced manual InputStream close with try-with-resources — no leak if IOException occurs 
* Added null guard for getAppCurrentActivity() + added missing Activity import — prevents NPE when app is in background
* Wrapped MotionEvent copy usage in try/finally with evCopy.recycle() — prevents pooled event leak
* Added removeView(mMapView) from parent before onDestroy() — prevents view leak from dangling in container
* Added preloadOverlaysList.clear() to clearPreloadObjects() — fixes memory leak of image overlays added before map is ready
* optimized saved-state code

[ti.map-android-6.0.0.zip](https://github.com/user-attachments/files/30549362/ti.map-android-6.0.0.zip)
(updated 26/07/30 - 15:40)

**Lite mode check:**
```js
var win = Titanium.UI.createWindow({
	layout:"vertical"
});
var Map = require('ti.map');

function createMap(liteMode) {
	var map = Map.createView({
		top: 10,
		right: 0,
		width: Ti.UI.FILL,
		height: 200,
		liteMode: liteMode,
		region: {
			zoom: 10,
			latitude: 46.893234,
			longitude: 1.346569,
		}
	});
	var an = Map.createAnnotation({
		title: 'Title',
		latitude: 46.893234,
		longitude: 1.346569,
	})
	map.addAnnotation(an);
	win.add(map);
}

createMap(true);	// liteMode map
createMap(false);	// normal map
win.open();
```

**ListView Header/Footer example**
```js
var Map = require('ti.map');

var map = Map.createView({
	top: 10,
	right: 0,
	width: Ti.UI.FILL,
	height: 200,
	region: {
		zoom: 10,
		latitude: 46.893234,
		longitude: 1.346569,
	}
});
var map2 = Map.createView({
	top: 10,
	right: 0,
	width: Ti.UI.FILL,
	height: 200,
	region: {
		zoom: 10,
		latitude: 46.893234,
		longitude: 1.346569,
	}
});
var an = Map.createAnnotation({
	title: 'Title',
	latitude: 46.893234,
	longitude: 1.346569,
})
map.addAnnotation(an);

var win = Ti.UI.createWindow();
var listView = Ti.UI.createListView();
var sections = [];

var fruitDataSet = [];
for (var i = 0; i < 100; i++) {
	fruitDataSet.push({properties: {
		title: "t" + i
	}});
}
var fruitSection = Ti.UI.createListSection({
	headerView: map,
	items: fruitDataSet
});
sections.push(fruitSection);

listView.sections = sections;
win.add(listView);
win.open();

var fishDataSet = [{
		properties: {
			title: 'Cod'
		}
	}
];
var fishSection = Ti.UI.createListSection({
	footerView: map2,
	items: fishDataSet
});
listView.appendSection(fishSection);
````

**Saved state test:**
```js
var Map = require('ti.map');

var win = Ti.UI.createWindow({ title: 'Restore test' });

// Intentionally NO `region` property: a fixed region would be re-applied on
// every view rebuild and mask whether the camera actually came back from the
// saved instance state.
var mapview = Map.createView({
      top: 40,
      mapType: Map.NORMAL_TYPE,
      annotations: [Map.createAnnotation({
              latitude: 48.137,
              longitude: 11.575,
              title: 'Munich'
      })]
});

var label = Ti.UI.createLabel({
      top: 0,
      height: 40,
      text: 'pan/zoom somewhere, then leave & return'
});

mapview.addEventListener('regionchanged', function (e) {
      label.text = 'lat ' + e.latitude.toFixed(4)
              + '  lon ' + e.longitude.toFixed(4);
});

win.add(label);
win.add(mapview);
win.open();
```
1. On the device/emulator enable Developer options → Don't keep activities (this forces the activity to be destroyed with onSaveInstanceState on every Home press and recreated with the bundle on return — the exact path ViewProxy.onCreate → getSavedInstanceState() → MapView.onCreate(savedState) now covers).
2. Launch the app, pan/zoom to a distinctive spot (note the lat/lon in the label).
3. Press Home, then reopen the app from recents.

Expected with the fix: the map comes back at the position you left it, and it's still alive — panning fires regionchanged (label updates) and the Munich marker is tappable. 