### PR TITLE
fix: fixed typos in sources and apidoc

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -24,7 +24,7 @@ jobs:
 
     - name: Cache Node.js modules
       id: node-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: node_modules
         key: ${{ runner.OS }}-node-modules-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -26,7 +26,7 @@ jobs:
 
     - name: Cache Node.js modules
       id: node-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: node_modules
         key: ${{ runner.OS }}-node-modules-${{ hashFiles('package-lock.json') }}

--- a/android/src/ti/map/CameraProxy.java
+++ b/android/src/ti/map/CameraProxy.java
@@ -43,8 +43,8 @@ public class CameraProxy extends KrollProxy
 									  TiConvert.toDouble(point.get(TiC.PROPERTY_LONGITUDE)));
 			}
 		}
-		if (dict.containsKeyAndNotNull(MapModule.PROPERTY_ALTITIDE)) {
-			zoom = TiConvert.toFloat(dict.get(MapModule.PROPERTY_ALTITIDE));
+		if (dict.containsKeyAndNotNull(MapModule.PROPERTY_ALTITUDE)) {
+			zoom = TiConvert.toFloat(dict.get(MapModule.PROPERTY_ALTITUDE));
 		}
 		if (dict.containsKeyAndNotNull(MapModule.PROPERTY_HEADING)) {
 			heading = TiConvert.toFloat(dict.get(MapModule.PROPERTY_HEADING));
@@ -68,7 +68,7 @@ public class CameraProxy extends KrollProxy
 									  TiConvert.toDouble(point.get(TiC.PROPERTY_LONGITUDE)));
 			}
 		}
-		if (name.equals(MapModule.PROPERTY_ALTITIDE)) {
+		if (name.equals(MapModule.PROPERTY_ALTITUDE)) {
 			zoom = TiConvert.toFloat(value);
 		}
 		if (name.equals(MapModule.PROPERTY_HEADING)) {

--- a/android/src/ti/map/MapModule.java
+++ b/android/src/ti/map/MapModule.java
@@ -74,7 +74,7 @@ public class MapModule extends KrollModule implements OnMapsSdkInitializedCallba
 	public static final String PROPERTY_LITE_MODE = "liteMode";
 	public static final String PROPERTY_MIN_CLUSTER_SIZE = "minClusterSize";
 	public static final String PROPERTY_CENTER_COORDINATES = "centerCoordinates";
-	public static final String PROPERTY_ALTITIDE = "altitude";
+	public static final String PROPERTY_ALTITUDE = "altitude";
 	public static final String PROPERTY_HEADING = "heading";
 	public static final String PROPERTY_PITCH = "pitch";
 

--- a/android/src/ti/map/TiMapInfoWindow.java
+++ b/android/src/ti/map/TiMapInfoWindow.java
@@ -155,7 +155,7 @@ public class TiMapInfoWindow extends RelativeLayout
 		} else if (flag == RIGHT_PANE) {
 			pane = rightPane;
 		} else {
-			Log.e(TAG, "Invalid valud for flag in setLeftOrRightPane", Log.DEBUG_MODE);
+			Log.e(TAG, "Invalid value for flag in setLeftOrRightPane", Log.DEBUG_MODE);
 			return;
 		}
 
@@ -192,8 +192,8 @@ public class TiMapInfoWindow extends RelativeLayout
 	 * Analyze the touch event to find out:
 	 * 1. whether it is inside the info window and
 	 * 2. if it is, what the corresponding clicksource is.
-	 * The clicksource can be one of "leftPane", "title", "subtible", "rightPane" or null. Null means the event
-	 * is not inside "leftPane", "title", "subtible" or "rightPane".
+	 * The clicksource can be one of "leftPane", "title", "subtitle", "rightPane" or null. Null means the event
+	 * is not inside "leftPane", "title", "subtitle" or "rightPane".
 	 * @param ev The MotionEvent detected. Its coordinates are relative to the map view.
 	 * @param markerPoint The screen coordinate for the marker which displays the info window.
 	 * @param iconImageHeight The height of the marker icon.

--- a/android/src/ti/map/TiUIMapView.java
+++ b/android/src/ti/map/TiUIMapView.java
@@ -1260,7 +1260,7 @@ public class TiUIMapView extends TiUIFragment
 		if (annoProxy != null) {
 			String clicksource = annoProxy.getMapInfoWindow().getClicksource();
 			// The clicksource is null means the click event is not inside
-			// "leftPane", "title", "subtible"
+			// "leftPane", "title", "subtitle"
 			// or "rightPane". In this case, use "infoWindow" as the
 			// clicksource.
 			if (clicksource == null) {

--- a/apidoc/Circle.yml
+++ b/apidoc/Circle.yml
@@ -11,7 +11,7 @@ since: { android: "4.1.0", iphone: "4.1.0", ipad: "4.1.0", macos: "9.2.0" }
 platforms: [android, iphone, ipad, macos]
 properties:
   - name: center
-    summary: An object with longitude and latitude values. Can also be an array with longitude (index 0), latitude (index 1) touples.
+    summary: An object with longitude and latitude values. Can also be an array with longitude (index 0), latitude (index 1) tuples.
     availability: creation
     type: MapPointType
     optional: false

--- a/apidoc/Map.yml
+++ b/apidoc/Map.yml
@@ -642,7 +642,7 @@ examples:
             Ti.API.info('Clicked ' + event.clicksource + ' on ' + event.latitude + ', ' + event.longitude);
         });
 
-        windown.open();
+        window.open();
         ```
   - title: Alloy XML Markup
     example: |
@@ -803,7 +803,7 @@ properties:
 ---
 name: SearchCompletionOptions
 summary: Additional options to fine-tune the search request.
-description: The latitute and longitude describe the location, the delta values the distance to include.
+description: The latitude and longitude describe the location, the delta values the distance to include.
 properties:
   - name: region
     summary: |

--- a/apidoc/Polygon.yml
+++ b/apidoc/Polygon.yml
@@ -11,7 +11,7 @@ since: { android: "4.1.0", iphone: "4.1.0", ipad: "4.1.0", macos: "9.2.0" }
 platforms: [android, iphone, ipad, macos]
 properties:
   - name: points
-    summary: Array of map points making up the polygon. Can also be an array of longitude (index 0), latitude (index 1) touples.
+    summary: Array of map points making up the polygon. Can also be an array of longitude (index 0), latitude (index 1) tuples.
     availability: creation
     type: Array<MapPointType>
     optional: false

--- a/apidoc/Polyline.yml
+++ b/apidoc/Polyline.yml
@@ -40,7 +40,7 @@ properties:
     since: "5.1.0"
 
   - name: points
-    summary: Array of map points making up the polyline. Can also be an array of longitude (index 0), latitude (index 1) touples. On Android platform you can use an encoded polyline as string.
+    summary: Array of map points making up the polyline. Can also be an array of longitude (index 0), latitude (index 1) tuples. On Android platform you can use an encoded polyline as string.
     availability: creation
     type: [Array<MapPointType>, String]
     optional: false

--- a/apidoc/View.yml
+++ b/apidoc/View.yml
@@ -351,7 +351,7 @@ methods:
 
 events:
   - name: clusterstart
-    summary: Fired when a collision between annotations occures.
+    summary: Fired when a collision between annotations occurs.
     properties:
       - name: memberAnnotations
         summary: Array of annotations participating in clustering.
@@ -429,7 +429,7 @@ events:
 
         For polygon, polyline or circle, The `click` event includes the following values.
         `clicksource` is a string describing the shape type. `map` is the map view instance.
-        `latitude` and `longtitude` is the corresponding coordinates on the map where the user
+        `latitude` and `longitude` is the corresponding coordinates on the map where the user
         clicked in the shape.
     properties:
       - name: title
@@ -925,7 +925,7 @@ properties:
     summary: A Boolean value indicating whether the map can be zoomed by pinching or tapping.
     description: |
         When this property is set to `true` the a map view can be zoomed by pinching inwards to zoom out
-        and reverse to zoom in. Zooming in can also be accoplished by double-tapping the map view. Zooming
+        and reverse to zoom in. Zooming in can also be accomplished by double-tapping the map view. Zooming
         out can also be accomplished by two-finger tapping the map view.
     type: Boolean
     default: true
@@ -1081,7 +1081,7 @@ since: "6.3.0"
 properties:
   - name: memberAnnotations
     summary: |
-      Array of Modules.Map.Annotation, which is recieved in event 'clusteringstarted' as
+      Array of Modules.Map.Annotation, which is received in event 'clusteringstarted' as
       memberAnnotations.
     type: Array<Modules.Map.Annotation>
 

--- a/ios/Classes/TiMapAnnotationProxy.h
+++ b/ios/Classes/TiMapAnnotationProxy.h
@@ -21,7 +21,7 @@
   CGPoint offset;
 }
 
-// Center latitude and longitude of the annotion view.
+// Center latitude and longitude of the annotation view.
 @property (nonatomic, readonly) CLLocationCoordinate2D coordinate;
 @property (nonatomic, readwrite, assign) TiMapViewProxy *delegate;
 @property (nonatomic, readonly) BOOL needsRefreshingWithSelection;

--- a/ios/Classes/TiMapView.m
+++ b/ios/Classes/TiMapView.m
@@ -1155,7 +1155,7 @@ CLLocationCoordinate2D userNewLocation;
 
     selectedAnnotation = [ann retain];
 
-    // If canShowCallout == YES we will try to find calloutView to hadleTap on callout
+    // If canShowCallout == YES we will try to find calloutView to handle tap on callout
     if ([ann canShowCallout]) {
       dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.2 * NSEC_PER_SEC), dispatch_get_main_queue(), ^(void) {
         [self findCalloutView:ann];
@@ -1326,7 +1326,7 @@ CLLocationCoordinate2D userNewLocation;
 }
 // mapView:viewForAnnotation: provides the view for each annotation.
 // This method may be called for all or some of the added annotations.
-// For MapKit provided annotations (eg. MKUserLocation) return nil to use the MapKit provided annotatiown view.
+// For MapKit provided annotations (e.g. MKUserLocation) return nil to use the MapKit provided annotation view.
 - (MKAnnotationView *)mapView:(MKMapView *)mapView viewForAnnotation:(id<MKAnnotation>)annotation
 {
   if ([annotation isKindOfClass:[TiMapAnnotationProxy class]]) {
@@ -1530,7 +1530,7 @@ CLLocationCoordinate2D userNewLocation;
         // Polyline points are equal, which means line length is zero. Use distance from one of the poly points.
         distanceFromLine = lengthA;
       } else {
-        // Touch point is between polyline's points. Calculte distance with Heron's formula.
+        // Touch point is between polyline's points. Calculate distance with Heron's formula.
         double value = (lengthA + lengthB + lengthC) / 2.0;
         double area = sqrt((value - lengthA) * (value - lengthB) * (value - lengthC) * value);
         distanceFromLine = (area * 2.0) / lengthC;

--- a/ios/Classes/TiMapViewProxy.h
+++ b/ios/Classes/TiMapViewProxy.h
@@ -22,8 +22,8 @@
   NSMutableArray *circlesToRemove;
   NSMutableArray *polylinesToAdd;
   NSMutableArray *polylinesToRemove;
-  NSMutableArray *imageOvelaysToAdd;
-  NSMutableArray *imageOvelaysToRemove;
+  NSMutableArray *imageOverlaysToAdd;
+  NSMutableArray *imageOverlaysToRemove;
 
   int zoomCount; // Number of times to zoom in/out on initial display
 }

--- a/ios/Classes/TiMapViewProxy.m
+++ b/ios/Classes/TiMapViewProxy.m
@@ -40,8 +40,8 @@
   RELEASE_TO_NIL(circlesToRemove);
   RELEASE_TO_NIL(polylinesToAdd);
   RELEASE_TO_NIL(polylinesToRemove);
-  RELEASE_TO_NIL(imageOvelaysToAdd);
-  RELEASE_TO_NIL(imageOvelaysToRemove);
+  RELEASE_TO_NIL(imageOverlaysToAdd);
+  RELEASE_TO_NIL(imageOverlaysToRemove);
   [super _destroy];
 }
 
@@ -123,11 +123,11 @@
     [ourView removePolyline:arg];
   }
 
-  for (id arg in imageOvelaysToAdd) {
+  for (id arg in imageOverlaysToAdd) {
     [ourView addImageOverlay:arg];
   }
 
-  for (id arg in imageOvelaysToRemove) {
+  for (id arg in imageOverlaysToRemove) {
     [ourView removeImageOverlay:arg];
   }
 
@@ -805,13 +805,13 @@
         },
         NO);
   } else {
-    if (imageOvelaysToAdd == nil) {
-      imageOvelaysToAdd = [[NSMutableArray alloc] init];
+    if (imageOverlaysToAdd == nil) {
+      imageOverlaysToAdd = [[NSMutableArray alloc] init];
     }
-    if (imageOvelaysToRemove != nil && [imageOvelaysToRemove containsObject:arg]) {
-      [imageOvelaysToRemove removeObject:arg];
+    if (imageOverlaysToRemove != nil && [imageOverlaysToRemove containsObject:arg]) {
+      [imageOverlaysToRemove removeObject:arg];
     } else {
-      [imageOvelaysToAdd addObject:arg];
+      [imageOverlaysToAdd addObject:arg];
     }
   }
 }
@@ -827,13 +827,13 @@
         },
         NO);
   } else {
-    if (imageOvelaysToRemove == nil) {
-      imageOvelaysToRemove = [[NSMutableArray alloc] init];
+    if (imageOverlaysToRemove == nil) {
+      imageOverlaysToRemove = [[NSMutableArray alloc] init];
     }
-    if (imageOvelaysToAdd != nil && [imageOvelaysToAdd containsObject:arg]) {
-      [imageOvelaysToAdd removeObject:arg];
+    if (imageOverlaysToAdd != nil && [imageOverlaysToAdd containsObject:arg]) {
+      [imageOverlaysToAdd removeObject:arg];
     } else {
-      [imageOvelaysToRemove addObject:arg];
+      [imageOverlaysToRemove addObject:arg];
     }
   }
 }
@@ -864,14 +864,14 @@
   if (attached) {
     TiThreadPerformOnMainThread(
         ^{
-          [(TiMapView *)[self view] addImageOverlays:imageOvelaysToAdd];
+          [(TiMapView *)[self view] addImageOverlays:imageOverlaysToAdd];
           [initialImageOverlays release];
         },
         NO);
   } else {
-    RELEASE_TO_NIL(imageOvelaysToAdd);
-    RELEASE_TO_NIL(imageOvelaysToRemove);
-    imageOvelaysToAdd = [[NSMutableArray alloc] initWithArray:initialImageOverlays];
+    RELEASE_TO_NIL(imageOverlaysToAdd);
+    RELEASE_TO_NIL(imageOverlaysToRemove);
+    imageOverlaysToAdd = [[NSMutableArray alloc] initWithArray:initialImageOverlays];
   }
 }
 

--- a/test/unit/karma.unit.config.js
+++ b/test/unit/karma.unit.config.js
@@ -11,7 +11,7 @@ function projectManagerHook(projectManager) {
 		console.log(`Copying ${src} to ${dest}`);
 		fs.copySync(src, dest);
 
-		// Trun off app thinning so images don't get shoved in asset catalog
+		// Turn off app thinning so images don't get shoved in asset catalog
 		const tiapp = path.join(this.karmaRunnerProjectPath, 'tiapp.xml');
 		const contents = fs.readFileSync(tiapp, 'utf8');
 		fs.writeFileSync(tiapp, contents.replace('</ios>', `<use-app-thinning>false</use-app-thinning>

--- a/test/unit/specs/route.spec.js
+++ b/test/unit/specs/route.spec.js
@@ -33,7 +33,7 @@ describe('ti.map.Route', () => {
 		});
 	});
 
-	it('instace should be defined', () => {
+	it('instance should be defined', () => {
 		expect(route1).not.toEqual(undefined);
 	});
 


### PR DESCRIPTION
**Description:**
- fixed constant name `PROPERTY_ALTITIDE` &rarr; `PROPERTY_ALTITUDE`
- fixed array name `imageOvelaysToAdd` &rarr; `imageOverlaysToAdd`
- fixed array name`imageOvelaysToRemove` &rarr; `imageOverlaysToRemove`
- fixed typos in logs and comments
- fixed typos in apidoc

**Note:** This change does not break the API.

**Edit:** updated iOS and JS workflows to cache@v4 because of failed CI checks