### PR TITLE
chore: move tooling to latest

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   android:
-    runs-on: macos-13
+    runs-on: macos-latest
     name: Android
     env:
       CCACHE_DIR: ${{ github.workspace }}/.ccache
@@ -23,7 +23,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '20.x'
+        node-version: '24.x'
 
     - name: Cache Node.js modules
       id: node-cache
@@ -56,7 +56,7 @@ jobs:
       name: Install Titanium CLI
 
 # TODO: Cache sdk install
-    - run: ti sdk install 12.8.0.GA
+    - run: ti sdk install 13.2.0.GA
       name: Install Titanium SDK
 
     - name: Install ccache

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '20.x'
+        node-version: '24.x'
 
     - run: npm ci
       name: Install dependencies

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -24,7 +24,7 @@ jobs:
 
     - name: Cache Node.js modules
       id: node-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: node_modules
         key: ${{ runner.OS }}-node-modules-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '20.x'
+        node-version: '24.x'
 
     - name: Cache Node.js modules
       id: node-cache
@@ -44,11 +44,11 @@ jobs:
 
 # TODO cache SDK install
 
-    - run: ti sdk install 12.8.0.GA
+    - run: ti sdk install 13.2.0.GA
       name: Install Titanium SDK
 
-    - run: sed -i .bak 's/TITANIUM_SDK_VERSION = .*/TITANIUM_SDK_VERSION = 12.5.1.GA/' ios/titanium.xcconfig
-      name: Set to Build with 12.5.1.GA SDK
+    - run: sed -i .bak 's/TITANIUM_SDK_VERSION = .*/TITANIUM_SDK_VERSION = 13.2.0.GA/' ios/titanium.xcconfig
+      name: Set to Build with 13.2.0.GA SDK
 
     # - run: npm run test:ios -- --sdkVersion 11.0.0.GA
     #   name: Build and Test

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -22,11 +22,11 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '20.x'
+        node-version: '24.x'
 
     - name: Cache Node.js modules
       id: node-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: node_modules
         key: ${{ runner.OS }}-node-modules-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/regen-docs.yml
+++ b/.github/workflows/regen-docs.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Setup node
       uses: actions/setup-node@v2
       with:
-        node-version: '16'
+        node-version: '24'
         registry-url: 'https://registry.npmjs.org'
 
     - name: Install dependencies


### PR DESCRIPTION
This pull request updates the CI workflows to use newer versions of Node.js and the Titanium SDK across Android, iOS, and documentation-related jobs. These updates ensure that the CI environment is aligned with the latest supported toolchains and dependencies.

**CI Environment Updates:**

* Updated Node.js version from `20.x` (and `16` in one workflow) to `24.x` (or `24`) in the Android, iOS, docs, and regen-docs workflows to ensure compatibility with the latest Node.js features and security updates. [[1]](diffhunk://#diff-b46b6cdc887427355980140454172d7b5ff3dd1f68523667bdd4947358d927d8L26-R26) [[2]](diffhunk://#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2cL20-R20) [[3]](diffhunk://#diff-fc40e39603744467ec4d9d7cb6c3bd67756ec09c037d03f3655904fc1c6bcfdaL23-R23) [[4]](diffhunk://#diff-8b849c34b28aab600ed2edc5dc34bf19287d6b3fffed096a116b5f30bfa5969cL23-R23)
* Changed the runner for the Android workflow from `macos-13` to `macos-latest` to use the most up-to-date macOS environment in CI.

**SDK Upgrades:**

* Upgraded the Titanium SDK installation in both Android and iOS workflows from `12.8.0.GA` to `13.2.0.GA`, ensuring builds use the latest SDK version. [[1]](diffhunk://#diff-b46b6cdc887427355980140454172d7b5ff3dd1f68523667bdd4947358d927d8L59-R59) [[2]](diffhunk://#diff-fc40e39603744467ec4d9d7cb6c3bd67756ec09c037d03f3655904fc1c6bcfdaL47-R51)
* Updated the iOS build configuration to set `TITANIUM_SDK_VERSION` to `13.2.0.GA` in `ios/titanium.xcconfig` (was previously `12.5.1.GA`).